### PR TITLE
code rework for views.py oauth method

### DIFF
--- a/policykit/slackintegration/models.py
+++ b/policykit/slackintegration/models.py
@@ -24,7 +24,7 @@ class SlackCommunity(Community):
                                     max_length=300, 
                                     unique=True)
     
-    bot_id = models.CharField('bot_id', max_length=150, unique=True, default=None, null=True, blank=True)
+    bot_id = models.CharField('bot_id', max_length=150, unique=True, default='')
     
     def notify_action(self, action, policy, users, post_type='channel', template=None, channel=None):
         from slackintegration.views import post_policy

--- a/policykit/slackintegration/models.py
+++ b/policykit/slackintegration/models.py
@@ -24,7 +24,7 @@ class SlackCommunity(Community):
                                     max_length=300, 
                                     unique=True)
     
-    bot_id = models.CharField('bot_id', max_length=150, unique=True)
+    bot_id = models.CharField('bot_id', max_length=150, unique=True, default=None)
     
     def notify_action(self, action, policy, users, post_type='channel', template=None, channel=None):
         from slackintegration.views import post_policy

--- a/policykit/slackintegration/models.py
+++ b/policykit/slackintegration/models.py
@@ -23,7 +23,9 @@ class SlackCommunity(Community):
     access_token = models.CharField('access_token', 
                                     max_length=300, 
                                     unique=True)
-    
+                                    
+    bot_id = models.CharField('bot_id', max_length=150, unique=True, default='')
+
     def notify_action(self, action, policy, users, post_type='channel', template=None, channel=None):
         from slackintegration.views import post_policy
         post_policy(policy, action, users, post_type, template, channel)

--- a/policykit/slackintegration/models.py
+++ b/policykit/slackintegration/models.py
@@ -24,7 +24,7 @@ class SlackCommunity(Community):
                                     max_length=300, 
                                     unique=True)
                                     
-    bot_id = models.CharField('bot_id', max_length=150, unique=True)
+                                    #bot_id = models.CharField('bot_id', max_length=150, unique=True)
     
     def notify_action(self, action, policy, users, post_type='channel', template=None, channel=None):
         from slackintegration.views import post_policy

--- a/policykit/slackintegration/models.py
+++ b/policykit/slackintegration/models.py
@@ -19,6 +19,8 @@ class SlackCommunity(Community):
     API = 'https://slack.com/api/'
     
     team_id = models.CharField('team_id', max_length=150, unique=True)
+    
+    bot_id = models.CharField('bot_id', max_length=150, unique=True)
 
     access_token = models.CharField('access_token', 
                                     max_length=300, 

--- a/policykit/slackintegration/models.py
+++ b/policykit/slackintegration/models.py
@@ -24,7 +24,7 @@ class SlackCommunity(Community):
                                     max_length=300, 
                                     unique=True)
     
-    bot_id = models.CharField('bot_id', max_length=150, unique=True, default=None)
+    bot_id = models.CharField('bot_id', max_length=150, unique=True, default=None, null=True, blank=True)
     
     def notify_action(self, action, policy, users, post_type='channel', template=None, channel=None):
         from slackintegration.views import post_policy

--- a/policykit/slackintegration/models.py
+++ b/policykit/slackintegration/models.py
@@ -24,8 +24,6 @@ class SlackCommunity(Community):
                                     max_length=300, 
                                     unique=True)
     
-    bot_id = models.CharField('bot_id', max_length=150, unique=True, default='')
-    
     def notify_action(self, action, policy, users, post_type='channel', template=None, channel=None):
         from slackintegration.views import post_policy
         post_policy(policy, action, users, post_type, template, channel)

--- a/policykit/slackintegration/models.py
+++ b/policykit/slackintegration/models.py
@@ -23,8 +23,8 @@ class SlackCommunity(Community):
     access_token = models.CharField('access_token', 
                                     max_length=300, 
                                     unique=True)
-                                    
-                                    #bot_id = models.CharField('bot_id', max_length=150, unique=True)
+    
+    bot_id = models.CharField('bot_id', max_length=150, unique=True)
     
     def notify_action(self, action, policy, users, post_type='channel', template=None, channel=None):
         from slackintegration.views import post_policy

--- a/policykit/slackintegration/models.py
+++ b/policykit/slackintegration/models.py
@@ -19,12 +19,12 @@ class SlackCommunity(Community):
     API = 'https://slack.com/api/'
     
     team_id = models.CharField('team_id', max_length=150, unique=True)
-    
-    bot_id = models.CharField('bot_id', max_length=150, unique=True)
 
     access_token = models.CharField('access_token', 
                                     max_length=300, 
                                     unique=True)
+                                    
+    bot_id = models.CharField('bot_id', max_length=150, unique=True)
     
     def notify_action(self, action, policy, users, post_type='channel', template=None, channel=None):
         from slackintegration.views import post_policy

--- a/policykit/slackintegration/views.py
+++ b/policykit/slackintegration/views.py
@@ -76,19 +76,20 @@ def oauth(request):
             respInfo = urllib.request.urlopen(reqInfo)
             resInfo = json.loads(respInfo.read())
             
+            if resInfo['user']['is_admin'] == False:
+                response = redirect('/login?error=user_is_not_an_admin')
+                return response
+            
             s = SlackCommunity.objects.filter(team_id=res['team']['id'])
             community = None
             user_group,_ = CommunityRole.objects.get_or_create(name="Slack: " + res['team']['name'] + ": Base User")
             user = SlackUser.objects.filter(username=res['authed_user']['id'])
-                                       
-            if resInfo['user']['is_admin'] == False:
-                response = redirect('/login?error=user_is_not_an_admin')
-                return response
         
             if not s.exists():
                 community = SlackCommunity.objects.create(
                     community_name=res['team']['name'],
                     team_id=res['team']['id'],
+                    bot_id=res['bot_user_id'],
                     access_token=res['access_token'],
                     base_role=user_group
                     )
@@ -125,6 +126,7 @@ def oauth(request):
                 community = s[0]
                 community.community_name = res['team']['name']
                 community.team_id = res['team']['id']
+                community.bot_id = res['bot_user_id']
                 community.access_token = res['access_token']
                 community.save()
 

--- a/policykit/slackintegration/views.py
+++ b/policykit/slackintegration/views.py
@@ -89,7 +89,6 @@ def oauth(request):
                 community = SlackCommunity.objects.create(
                     community_name=res['team']['name'],
                     team_id=res['team']['id'],
-                                                          #bot_id=res['bot_user_id'],
                     access_token=res['access_token'],
                     base_role=user_group
                     )
@@ -126,7 +125,6 @@ def oauth(request):
                 community = s[0]
                 community.community_name = res['team']['name']
                 community.team_id = res['team']['id']
-                #community.bot_id = res['bot_user_id']
                 community.access_token = res['access_token']
                 community.save()
 

--- a/policykit/slackintegration/views.py
+++ b/policykit/slackintegration/views.py
@@ -89,6 +89,7 @@ def oauth(request):
                 community = SlackCommunity.objects.create(
                     community_name=res['team']['name'],
                     team_id=res['team']['id'],
+                    community.bot_id = res['bot_user_id'],
                     access_token=res['access_token'],
                     base_role=user_group
                     )
@@ -125,6 +126,7 @@ def oauth(request):
                 community = s[0]
                 community.community_name = res['team']['name']
                 community.team_id = res['team']['id']
+                community.bot_id = res['bot_user_id']
                 community.access_token = res['access_token']
                 community.save()
 

--- a/policykit/slackintegration/views.py
+++ b/policykit/slackintegration/views.py
@@ -119,7 +119,7 @@ def oauth(request):
                                                          is_community_admin=True,
                                                          community=community)
                             elif new_user['is_bot']:
-                                community.bot_id = new_user['id']d
+                                community.bot_id = new_user['id']
                             else:
                                 u,_ = SlackUser.objects.get_or_create(username=new_user['id'], readable_name=new_user['real_name'], community=community)
                 

--- a/policykit/slackintegration/views.py
+++ b/policykit/slackintegration/views.py
@@ -89,7 +89,6 @@ def oauth(request):
                 community = SlackCommunity.objects.create(
                     community_name=res['team']['name'],
                     team_id=res['team']['id'],
-                    bot_id=res['bot_user_id'],
                     access_token=res['access_token'],
                     base_role=user_group
                     )
@@ -126,7 +125,6 @@ def oauth(request):
                 community = s[0]
                 community.community_name = res['team']['name']
                 community.team_id = res['team']['id']
-                community.bot_id = res['bot_user_id']
                 community.access_token = res['access_token']
                 community.save()
 

--- a/policykit/slackintegration/views.py
+++ b/policykit/slackintegration/views.py
@@ -89,7 +89,7 @@ def oauth(request):
                 community = SlackCommunity.objects.create(
                     community_name=res['team']['name'],
                     team_id=res['team']['id'],
-                    bot_id=res['bot_user_id'],
+                                                          #bot_id=res['bot_user_id'],
                     access_token=res['access_token'],
                     base_role=user_group
                     )
@@ -126,7 +126,7 @@ def oauth(request):
                 community = s[0]
                 community.community_name = res['team']['name']
                 community.team_id = res['team']['id']
-                community.bot_id = res['bot_user_id']
+                #community.bot_id = res['bot_user_id']
                 community.access_token = res['access_token']
                 community.save()
 

--- a/policykit/slackintegration/views.py
+++ b/policykit/slackintegration/views.py
@@ -89,6 +89,7 @@ def oauth(request):
                 community = SlackCommunity.objects.create(
                     community_name=res['team']['name'],
                     team_id=res['team']['id'],
+                    bot_id=res['bot_user_id'],
                     access_token=res['access_token'],
                     base_role=user_group
                     )
@@ -118,8 +119,6 @@ def oauth(request):
                                                          access_token=res['authed_user']['access_token'],
                                                          is_community_admin=True,
                                                          community=community)
-                            elif new_user['is_bot']:
-                                community.bot_id = new_user['id']
                             else:
                                 u,_ = SlackUser.objects.get_or_create(username=new_user['id'], readable_name=new_user['real_name'], community=community)
                 
@@ -127,6 +126,7 @@ def oauth(request):
                 community = s[0]
                 community.community_name = res['team']['name']
                 community.team_id = res['team']['id']
+                community.bot_id = res['bot_user_id']
                 community.access_token = res['access_token']
                 community.save()
 

--- a/policykit/slackintegration/views.py
+++ b/policykit/slackintegration/views.py
@@ -94,7 +94,7 @@ def oauth(request):
                     )
                 user_group.community = community
                 user_group.save()
-                    
+                
                 cg = CommunityDoc.objects.create(text='', community=community)
                     
                 community.community_guidelines=cg
@@ -114,7 +114,7 @@ def oauth(request):
                     for new_user in res2['members']:
                         if (not new_user['deleted']) and (not new_user['is_bot']) and (new_user['id'] != 'USLACKBOT'):
                             if new_user['id'] == res['authed_user']['id']:
-                                u,_ = SlackUser.objects.get_or_create(username=res['authed_user']['id'], readable_name=new_user['real_name']
+                                u,_ = SlackUser.objects.get_or_create(username=res['authed_user']['id'], readable_name=new_user['real_name'],
                                                          access_token=res['authed_user']['access_token'],
                                                          is_community_admin=True,
                                                          community=community)


### PR DESCRIPTION
addresses #43, by making sure that all users, including admin that logged in, have their readable_name attribute filled in (no more duplicate Nones created). also prevents from unnecessary SlackUser/SlackCommunity objects being created when a non-admin tries to integrate.

Edit: this integrates Ricky's code for addressing #45 

Update: also adds the bot_id field, addressing #7 