### PR TITLE
fix(): add django-activity-stream to requirements.txt

### DIFF
--- a/policykit/.gitignore
+++ b/policykit/.gitignore
@@ -5,4 +5,3 @@ db.sqlite3
 static/*
 *migrations*
 .DS_Store
-*logs*

--- a/policykit/.gitignore
+++ b/policykit/.gitignore
@@ -5,3 +5,4 @@ db.sqlite3
 static/*
 *migrations*
 .DS_Store
+*logs*

--- a/policykit/policykit/settings.py
+++ b/policykit/policykit/settings.py
@@ -171,7 +171,7 @@ LOGGING = {
         'file': {
             'level': 'DEBUG',
             'class': 'logging.FileHandler',
-            'filename': '/var/log/django/debug.log',
+            'filename': '/Users/arnaudschenk/dev/policykit/policykit/logs/debug.log',
         },
     },
     'loggers': {

--- a/policykit/policykit/settings.py
+++ b/policykit/policykit/settings.py
@@ -171,7 +171,7 @@ LOGGING = {
         'file': {
             'level': 'DEBUG',
             'class': 'logging.FileHandler',
-            'filename': '/Users/arnaudschenk/dev/policykit/policykit/logs/debug.log',
+            'filename': '/var/log/django/debug.log',
         },
     },
     'loggers': {

--- a/policykit/requirements.txt
+++ b/policykit/requirements.txt
@@ -1,5 +1,6 @@
 amqp==2.5.2
 anyjson==0.3.3
+appnope==0.1.0
 asgiref==3.2.3
 backcall==0.1.0
 billiard==3.6.1.0
@@ -8,6 +9,7 @@ certifi==2019.11.28
 chardet==3.0.4
 decorator==4.4.1
 Django==3.0.7
+django-activity-stream==0.9.0
 django-celery-beat==1.5.0
 django-celery-results==1.1.2
 django-grappelli==2.14.1
@@ -15,6 +17,7 @@ django-jet==1.0.8
 django-polymorphic==2.1.2
 django-timezone-field==4.0
 gevent==20.6.2
+greenlet==0.4.17
 idna==2.9
 importlib-metadata==1.4.0
 ipython==7.11.1
@@ -39,5 +42,7 @@ urllib3==1.25.8
 vine==1.3.0
 wcwidth==0.1.8
 websocket==0.2.1
-websocket_client==0.57.0
+websocket-client==0.57.0
 zipp==2.0.1
+zope.event==4.5.0
+zope.interface==5.1.2


### PR DESCRIPTION
👋  small PR fixing an issue I ran into while getting setup.

### Description

While following the setup steps, all goes relatively smoothly (save some Mac OS/Python environment troubles) until it comes time to run the server which throws the following error:

```
% python manage.py runserver                                                                                                                        
Exception in thread django-main-thread:
Traceback (most recent call last):
  File "/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.8/lib/python3.8/threading.py", line 932, in _bootstrap_inner
    self.run()
  File "/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.8/lib/python3.8/threading.py", line 870, in run
    self._target(*self._args, **self._kwargs)
  File "/Users/arnaudschenk/.virtualenv/policykit/lib/python3.8/site-packages/django/utils/autoreload.py", line 53, in wrapper
    fn(*args, **kwargs)
  File "/Users/arnaudschenk/.virtualenv/policykit/lib/python3.8/site-packages/django/core/management/commands/runserver.py", line 109, in inner_run
    autoreload.raise_last_exception()
  File "/Users/arnaudschenk/.virtualenv/policykit/lib/python3.8/site-packages/django/utils/autoreload.py", line 76, in raise_last_exception
    raise _exception[1]
  File "/Users/arnaudschenk/.virtualenv/policykit/lib/python3.8/site-packages/django/core/management/__init__.py", line 357, in execute
    autoreload.check_errors(django.setup)()
  File "/Users/arnaudschenk/.virtualenv/policykit/lib/python3.8/site-packages/django/utils/autoreload.py", line 53, in wrapper
    fn(*args, **kwargs)
  File "/Users/arnaudschenk/.virtualenv/policykit/lib/python3.8/site-packages/django/__init__.py", line 24, in setup
    apps.populate(settings.INSTALLED_APPS)
  File "/Users/arnaudschenk/.virtualenv/policykit/lib/python3.8/site-packages/django/apps/registry.py", line 91, in populate
    app_config = AppConfig.create(entry)
  File "/Users/arnaudschenk/.virtualenv/policykit/lib/python3.8/site-packages/django/apps/config.py", line 90, in create
    module = import_module(entry)
  File "/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.8/lib/python3.8/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1014, in _gcd_import
  File "<frozen importlib._bootstrap>", line 991, in _find_and_load
  File "<frozen importlib._bootstrap>", line 973, in _find_and_load_unlocked
ModuleNotFoundError: No module named 'actstream'

```
### Fix

Very straight forward fix: have just installed `django-activity-stream` and frozen the list of packages. Very infrequent user of Python, so if I've added too many new packages to `requirements.txt`, let me know! 

