### PR TITLE
Fix Slack action permission check

### DIFF
--- a/policykit/integrations/slack/views.py
+++ b/policykit/integrations/slack/views.py
@@ -241,10 +241,10 @@ def action(request):
                 new_api_action.channel = event['channel_id']
                 new_api_action.timestamp = event['item']['message']['ts']
 
-        if new_api_action.initiator.has_perm('slackintegration.add_' + new_api_action.action_codename):
+        if new_api_action.initiator.has_perm('slack.add_' + new_api_action.action_codename):
             if new_api_action and not policy_kit_action:
                 #if they have execute permission, skip all policies
-                if new_api_action.initiator.has_perm('slackintegration.can_execute_' + new_api_action.action_codename):
+                if new_api_action.initiator.has_perm('slack.can_execute_' + new_api_action.action_codename):
                     new_api_action.execute()
                 else:
                     for policy in PlatformPolicy.objects.filter(community=new_api_action.community):

--- a/policykit/policyengine/models.py
+++ b/policykit/policyengine/models.py
@@ -285,7 +285,7 @@ class ConstitutionAction(BaseAction, PolymorphicModel):
     def save(self, *args, **kwargs):
         if self.shouldCreate():
             #runs only if they have propose permission
-            if self.initiator.has_perm(self.app_name + '.add_' + self.action_codename):
+            if self.initiator.has_perm(self._meta.app_label + '.add_' + self.action_codename):
                 if hasattr(self, 'proposal'):
                     self.proposal.status = Proposal.PROPOSED
                 else:
@@ -776,7 +776,7 @@ class PlatformAction(BaseAction,PolymorphicModel):
         if not self.pk:
             logger.info('is pk')
             #runs only if they have propose permission
-            if self.initiator.has_perm(self.app_name + '.add_' + self.action_codename):
+            if self.initiator.has_perm(self._meta.app_label + '.add_' + self.action_codename):
                 logger.info('has propose permission')
                 p = Proposal.objects.create(status=Proposal.PROPOSED,
                                                 author=self.initiator)


### PR DESCRIPTION
The [has_perm function](https://docs.djangoproject.com/en/3.1/ref/contrib/auth/#django.contrib.auth.models.User.has_perm) accepts a string in the format `"<app label>.<permission codename>"`.

Here we were using prefix `slackintegration` (which comes from the PlatformAction `app_name` property) instead of `slack` which is the app label.

I can't get PolicyKit to work without this because the `slackintegration.*` permissions just don't exist. Could this have something to do with how I set it up, or the starter kits? I followed the README instructions to get going, and using the django shell I could see that my User had permissions `slack.add_slackpinmessage` etc (NOT `slackintegration.add_slackpinmessage`).