### PR TITLE
Ignore Slack events initiated by PolicyKit bot

### DIFF
--- a/policykit/integrations/slack/views.py
+++ b/policykit/integrations/slack/views.py
@@ -161,8 +161,7 @@ def is_policykit_bot_action(community, event):
 
 def is_policykit_action(integration, test_a, test_b, api_name):
     current_time_minus = datetime.datetime.now() - datetime.timedelta(seconds=2)
-    logs = LogAPICall.objects.filter(proposal_time__gte=current_time_minus,
-                                            call_type=integration.API + api_name)
+    logs = LogAPICall.objects.filter(proposal_time__gte=current_time_minus, call_type=api_name)
 
     if logs.exists():
         for log in logs:


### PR DESCRIPTION
Ignore Slack events where the `user` is the PolicyKit bot. Needed to skip governing when the bot performs a `message` or `pin_added` event. For some reason the `is_policykit_action` function that uses a 2-second heuristic wasn't catching it. I left that check in addition to the new check for bot id. 

Also refactor the action function a bit for clarity, and get rid of NoneType errors that were happening.