### PR TITLE
Log exceptions from exec_code

### DIFF
--- a/policykit/policyengine/views.py
+++ b/policykit/policyengine/views.py
@@ -304,7 +304,11 @@ def exec_code(code, wrapperStart, wrapperEnd, globals=None, locals=None):
     lines = ['  ' + item for item in code.splitlines()]
     code = wrapperStart + '\r\n'.join(lines) + wrapperEnd
 
-    exec(code, globals, locals)
+    try:
+        exec(code, globals, locals)
+    except Exception as e:
+        logger.exception('Got exception in exec_code:')
+        raise
 
 def filter_policy(policy, action):
     from policyengine.models import CommunityUser


### PR DESCRIPTION
This will log an error if one is raised in exec_code, to help debugging:

```
20210223_160940:Got exception in exec_code:
20210223_160940:Traceback (most recent call last):
20210223_160940:File /policykit/policykit/policyengine/views.py, line 308, in exec_code
20210223_160940:exec(code, globals, locals)
20210223_160940:File <string>, line 15, in <module>
20210223_160940:File <string>, line 11, in check
20210223_160940:NameError: name outcome is not defined
```

We should surface this to the user somehow –– currently there is no way for them to know that the policy is throwing an exception. Celery just gets killed and keeps trying to execute it indefinitely.