### PR TITLE
Encapsulate policy execution in "execute_policy" func, and some bug fixes

### DIFF
--- a/docs/source/api_policy.rst
+++ b/docs/source/api_policy.rst
@@ -17,8 +17,6 @@ BasePolicy
 +--------------+------------------------------------------------------------------------------------+
 | is_bundled   | True if the policy is part of a bundle.                                            |
 +--------------+------------------------------------------------------------------------------------+
-| has_notified | True if the policy has sent a notification to the community.                       |
-+--------------+------------------------------------------------------------------------------------+
 | data         | The datastore containing any additional data for the policy. May or may not exist. |
 +--------------+------------------------------------------------------------------------------------+
 | filter       | The filter code of the policy.                                                     |

--- a/policykit/integrations/discord/models.py
+++ b/policykit/integrations/discord/models.py
@@ -80,16 +80,17 @@ class DiscordCommunity(Community):
         req.add_header('Content-Type', 'application/x-www-form-urlencoded')
         req.add_header("User-Agent", "Mozilla/5.0") # yes, this is strange. discord requires it when using urllib for some weird reason
 
-        res = None
         try:
             resp = urllib.request.urlopen(req)
-            res = json.loads(resp.read().decode('utf-8'))
         except urllib.error.HTTPError as e:
             logger.info('reached HTTPError')
             logger.info(e.code)
             raise
 
-        return res
+        res = resp.read().decode('utf-8')
+        if res:
+            return json.loads(res)
+        return None
 
     def execute_platform_action(self, action, delete_policykit_post=True):
         from policyengine.models import LogAPICall, CommunityUser

--- a/policykit/integrations/discord/views.py
+++ b/policykit/integrations/discord/views.py
@@ -243,13 +243,14 @@ def oauth(request):
             req.add_header("User-Agent", "Mozilla/5.0") # yes, this is strange. discord requires it when using urllib for some weird reason
             resp = urllib.request.urlopen(req)
             guild_members = json.loads(resp.read().decode('utf-8'))
-
+            owner_id = res['guild']['owner_id']
             for member in guild_members:
                 user, _ = DiscordUser.objects.get_or_create(
                     username=member['user']['id'],
                     readable_name=member['user']['username'],
                     avatar = member['user']['avatar'],
-                    community=community
+                    community=community,
+                    is_community_admin=(member['user']['id'] == owner_id)
                 )
                 user.save()
         else:

--- a/policykit/integrations/discourse/models.py
+++ b/policykit/integrations/discourse/models.py
@@ -126,11 +126,10 @@ class DiscourseUser(CommunityUser):
         group.user_set.add(self)
 
 class DiscourseCreateTopic(PlatformAction):
-    id = None
-
     title = models.TextField()
     raw = models.TextField()
-    category = models.TextField(blank=True)
+    topic_id = models.IntegerField()
+    category = models.IntegerField()
 
     ACTION = 'posts.json'
     AUTH = 'user'
@@ -147,20 +146,20 @@ class DiscourseCreateTopic(PlatformAction):
     def revert(self):
         logger.info('discourse topic revert')
         values = {}
-        call = f"/t/{self.id}.json"
+        call = f"/t/{self.topic_id}.json"
         super().revert(values, call, method='DELETE')
 
     def execute(self):
-        # FIXME(#335)
-        # if not self.community_revert:
-        #     topic = self.community.make_call('/posts.json', {'title': self.title, 'raw': self.raw, 'category': self.category})
-        #     self.id = topic['id']
+        if not self.community_revert:
+            topic = self.community.make_call('/posts.json', {'title': self.title, 'raw': self.raw, 'category': self.category})
+
+            self.topic_id = topic['id']
+            self.save()
         super().pass_action()
 
 class DiscourseCreatePost(PlatformAction):
-    id = None
-
     raw = models.TextField()
+    post_id = models.IntegerField()
 
     ACTION = 'posts.json'
     AUTH = 'user'
@@ -176,14 +175,14 @@ class DiscourseCreatePost(PlatformAction):
 
     def revert(self):
         values = {}
-        call = f"/posts/{self.id}.json"
+        call = f"/posts/{self.post_id}.json"
         super().revert(values, call, method='DELETE')
 
     def execute(self):
-        # FIXME(#335)
-        # if not self.community_revert:
-        #     reply = self.community.make_call('/posts.json', {'raw': self.raw})
-        #     self.id = reply['id']
+        if not self.community_revert:
+            reply = self.community.make_call('/posts.json', {'raw': self.raw})
+            self.post_id = reply['id']
+            self.save()
         super().pass_action()
 
 class DiscourseStarterKit(StarterKit):

--- a/policykit/integrations/discourse/tasks.py
+++ b/policykit/integrations/discourse/tasks.py
@@ -55,7 +55,7 @@ def discourse_listener_actions():
             username = usernames[0]
             call_type = '/posts.json'
             if not is_policykit_action(community, call_type, topic, username):
-                t = DiscourseCreateTopic.objects.filter(id=topic['id'])
+                t = DiscourseCreateTopic.objects.filter(community=community, topic_id=topic['id'])
                 if not t.exists():
                     logger.info(f"[celery-discourse] creating new DiscourseCreateTopic object for topic {topic['title']}")
 
@@ -72,7 +72,7 @@ def discourse_listener_actions():
                     new_api_action.title = topic['title']
                     new_api_action.category = topic['category_id']
                     new_api_action.raw = raw
-                    new_api_action.id = topic['id']
+                    new_api_action.topic_id = topic['id']
 
                     u,_ = DiscourseUser.objects.get_or_create(
                         username=username,

--- a/policykit/integrations/discourse/tasks.py
+++ b/policykit/integrations/discourse/tasks.py
@@ -4,7 +4,6 @@ from celery import shared_task
 from celery.schedules import crontab
 from policyengine.models import Proposal, LogAPICall, PlatformPolicy, PlatformAction, BooleanVote, NumberVote
 from integrations.discourse.models import DiscourseCommunity, DiscourseUser, DiscourseCreateTopic, DiscourseCreatePost
-from policyengine.views import filter_policy, check_policy, initialize_policy
 from urllib import parse
 import urllib.request
 import urllib.error
@@ -126,12 +125,3 @@ def discourse_listener_actions():
                                 vote.save()
                         else:
                             b = BooleanVote.objects.create(proposal=proposed_action.proposal, user=u, boolean_value=val)
-
-            # Update proposal
-            for policy in PlatformPolicy.objects.filter(community=community):
-                if filter_policy(policy, proposed_action):
-                    cond_result = check_policy(policy, proposed_action)
-                    if cond_result == Proposal.PASSED:
-                        pass_policy(policy, proposed_action)
-                    elif cond_result == Proposal.FAILED:
-                        fail_policy(policy, proposed_action)

--- a/policykit/integrations/metagov/models.py
+++ b/policykit/integrations/metagov/models.py
@@ -74,8 +74,7 @@ class MetagovPlatformAction(PlatformAction):
         return None
 
     def execute(self):
-        # because of https://github.com/amyxzhang/policykit/issues/305
-        self.pass_action()
+        pass
 
     def revert(self):
         pass

--- a/policykit/integrations/slack/models.py
+++ b/policykit/integrations/slack/models.py
@@ -21,6 +21,9 @@ SLACK_PROPOSE_PERMS = ['Can add slack post message', 'Can add slack schedule mes
 
 SLACK_EXECUTE_PERMS = ['Can execute slack post message', 'Can execute slack schedule message', 'Can execute slack rename conversation', 'Can execute slack kick conversation', 'Can execute slack join conversation', 'Can execute slack pin message']
 
+class SlackUser(CommunityUser):
+    pass
+
 class SlackCommunity(Community):
     API = 'https://slack.com/api/'
 
@@ -53,7 +56,7 @@ class SlackCommunity(Community):
 
     def execute_platform_action(self, action, delete_policykit_post=True):
 
-        from policyengine.models import LogAPICall, CommunityUser
+        from policyengine.models import LogAPICall
         from policyengine.views import clean_up_proposals
 
         obj = action
@@ -87,7 +90,7 @@ class SlackCommunity(Community):
             if obj.AUTH == "user":
                 data['token'] = action.proposal.author.access_token
                 if not data['token']:
-                    admin_user = CommunityUser.objects.filter(is_community_admin=True)[0]
+                    admin_user = SlackUser.objects.filter(community=action.community, is_community_admin=True)[0]
                     data['token'] = admin_user.access_token
             elif obj.AUTH == "admin_bot":
                 if action.proposal.author.is_community_admin:
@@ -95,7 +98,7 @@ class SlackCommunity(Community):
                 else:
                     data['token'] = self.access_token
             elif obj.AUTH == "admin_user":
-                admin_user = CommunityUser.objects.filter(is_community_admin=True)[0]
+                admin_user = SlackUser.objects.filter(community=action.community, is_community_admin=True)[0]
                 data['token'] = admin_user.access_token
             else:
                 data['token'] = self.access_token
@@ -123,7 +126,7 @@ class SlackCommunity(Community):
                     posted_action = action
 
                 if posted_action.community_post:
-                    admin_user = CommunityUser.objects.filter(is_community_admin=True)[0]
+                    admin_user = SlackUser.objects.filter(community=action.community, is_community_admin=True)[0]
                     values = {'token': admin_user.access_token,
                               'ts': posted_action.community_post,
                               'channel': obj.channel
@@ -142,9 +145,6 @@ class SlackCommunity(Community):
             clean_up_proposals(action, True)
 
 
-class SlackUser(CommunityUser):
-    pass
-
 class SlackPostMessage(PlatformAction):
     ACTION = 'chat.postMessage'
     AUTH = 'admin_bot'
@@ -160,7 +160,7 @@ class SlackPostMessage(PlatformAction):
         )
 
     def revert(self):
-        admin_user = SlackUser.objects.filter(is_community_admin=True)[0]
+        admin_user = SlackUser.objects.filter(community=self.community, is_community_admin=True)[0]
         values = {'token': admin_user.access_token,
                   'ts': self.time_stamp,
                   'channel': self.channel
@@ -218,7 +218,7 @@ class SlackJoinConversation(PlatformAction):
         )
 
     def revert(self):
-        admin_user = SlackUser.objects.filter(is_community_admin=True)[0]
+        admin_user = SlackUser.objects.filter(community=self.community, is_community_admin=True)[0]
         values = {'user': self.users,
                   'token': admin_user.access_token,
                   'channel': self.channel

--- a/policykit/integrations/slack/models.py
+++ b/policykit/integrations/slack/models.py
@@ -34,7 +34,7 @@ class SlackCommunity(Community):
 
     bot_id = models.CharField('bot_id', max_length=150, unique=True, default='')
 
-    def notify_action(self, action, policy, users, post_type='channel', template=None, channel=None):
+    def notify_action(self, action, policy, users=None, post_type='channel', template=None, channel=None):
         from integrations.slack.views import post_policy
         post_policy(policy, action, users, post_type, template, channel)
 
@@ -46,8 +46,10 @@ class SlackCommunity(Community):
         logger.info(f"Making call: {url}")
         req = urllib.request.Request(url)
         resp = urllib.request.urlopen(req)
-        res = json.loads(resp.read().decode('utf-8'))
-        return res
+        resp_body = resp.read().decode('utf-8')
+        if resp_body:
+            return json.loads(resp_body)
+        return None
 
     def execute_platform_action(self, action, delete_policykit_post=True):
 

--- a/policykit/policyengine/models.py
+++ b/policykit/policyengine/models.py
@@ -129,6 +129,9 @@ class PolymorphicUserManager(UserManager, PolymorphicManager):
     # no-op class to get rid of warnings (issue #270)
     pass
 
+# https://github.com/django-polymorphic/django-polymorphic/issues/9
+setattr(User, '_base_objects', User.objects)
+
 class CommunityUser(User, PolymorphicModel):
     readable_name = models.CharField('readable_name', max_length=300, null=True)
     community = models.ForeignKey(Community, models.CASCADE)

--- a/policykit/policyengine/models.py
+++ b/policykit/policyengine/models.py
@@ -247,7 +247,6 @@ class GenericPolicy(models.Model):
     success = models.TextField(null=True, blank=True, default='')
     fail = models.TextField(null=True, blank=True, default='')
     is_bundled = models.BooleanField(default=False)
-    has_notified = models.BooleanField(default=False)
     is_constitution = models.BooleanField(default=True)
 
     def __str__(self):
@@ -924,7 +923,6 @@ class BasePolicy(models.Model):
     )
     description = models.TextField(null=True, blank=True)
     is_bundled = models.BooleanField(default=False)
-    has_notified = models.BooleanField(default=False)
 
     data = models.OneToOneField(DataStore,
         models.CASCADE,

--- a/policykit/policyengine/tasks.py
+++ b/policykit/policyengine/tasks.py
@@ -9,15 +9,15 @@ from policyengine.views import *
 
 @shared_task
 def consider_proposed_actions():
-
     platform_actions = PlatformAction.objects.filter(proposal__status=Proposal.PROPOSED, is_bundled=False)
+    logger.info(f"[celery] {platform_actions.count()} proposed PlatformActions")
     for action in platform_actions:
          #if they have execute permission, skip all policies
         if action.initiator.has_perm(action.app_name + '.can_execute_' + action.action_codename):
             action.execute()
         else:
             for policy in PlatformPolicy.objects.filter(community=action.community):
-                execute_policy(policy, action)
+                execute_policy(policy, action, is_first_evaluation=False)
 
     """bundle_actions = PlatformActionBundle.objects.filter(proposal__status=Proposal.PROPOSED)
     for action in bundle_actions:
@@ -30,10 +30,13 @@ def consider_proposed_actions():
                 execute_policy(policy, action)"""
 
     constitution_actions = ConstitutionAction.objects.filter(proposal__status=Proposal.PROPOSED, is_bundled=False)
+    logger.info(f"[celery] {constitution_actions.count()} proposed ConstitutionActions")
     for action in constitution_actions:
         #if they have execute permission, skip all policies
         if action.initiator.has_perm(action.app_name + '.can_execute_' + action.action_codename):
             action.execute()
         else:
             for policy in ConstitutionPolicy.objects.filter(community=action.community):
-                execute_policy(policy, action)
+                execute_policy(policy, action, is_first_evaluation=False)
+
+    logger.info('[celery] finished task')

--- a/policykit/policyengine/tasks.py
+++ b/policykit/policyengine/tasks.py
@@ -3,30 +3,12 @@ from __future__ import absolute_import, unicode_literals
 
 from celery import shared_task
 from celery.schedules import crontab
-from policyengine.models import UserVote, NumberVote, BooleanVote, PlatformAction, PlatformActionBundle, Proposal, PlatformPolicy, CommunityUser, ConstitutionAction, ConstitutionPolicy
+from policyengine.models import UserVote, NumberVote, BooleanVote, PlatformAction, PlatformActionBundle, Proposal, PlatformPolicy, CommunityUser, ConstitutionAction, ConstitutionPolicy, execute_policy
 from policykit.celery import app
 from policyengine.views import *
 
 @shared_task
 def consider_proposed_actions():
-    def _execute_policy(policy, action):
-        if filter_policy(policy, action):
-            if not policy.has_notified:
-                initialize_policy(policy, action)
-
-                check_result = check_policy(policy, action)
-                if check_result == Proposal.PASSED:
-                    pass_policy(policy, action)
-                elif check_result == Proposal.FAILED:
-                    fail_policy(policy, action)
-                else:
-                    notify_policy(policy, action)
-            else:
-                check_result = check_policy(policy, action)
-                if check_result == Proposal.PASSED:
-                    pass_policy(policy, action)
-                elif check_result == Proposal.FAILED:
-                    fail_policy(policy, action)
 
     platform_actions = PlatformAction.objects.filter(proposal__status=Proposal.PROPOSED, is_bundled=False)
     for action in platform_actions:
@@ -35,7 +17,7 @@ def consider_proposed_actions():
             action.execute()
         else:
             for policy in PlatformPolicy.objects.filter(community=action.community):
-                _execute_policy(policy, action)
+                execute_policy(policy, action)
 
     """bundle_actions = PlatformActionBundle.objects.filter(proposal__status=Proposal.PROPOSED)
     for action in bundle_actions:
@@ -45,7 +27,7 @@ def consider_proposed_actions():
             action.execute()
         else:
             for policy in PlatformPolicy.objects.filter(community=action.community):
-                _execute_policy(policy, action)"""
+                execute_policy(policy, action)"""
 
     constitution_actions = ConstitutionAction.objects.filter(proposal__status=Proposal.PROPOSED, is_bundled=False)
     for action in constitution_actions:
@@ -54,4 +36,4 @@ def consider_proposed_actions():
             action.execute()
         else:
             for policy in ConstitutionPolicy.objects.filter(community=action.community):
-                _execute_policy(policy, action)
+                execute_policy(policy, action)

--- a/policykit/policyengine/views.py
+++ b/policykit/policyengine/views.py
@@ -367,9 +367,6 @@ def initialize_policy(policy, action):
 
     exec_code(policy.initialize, wrapper_start, wrapper_end, _globals, _locals)
 
-    policy.has_notified = True # this should be renamed 'is_initialized'
-    policy.save()
-
 def check_policy(policy, action):
     from policyengine.models import Proposal, CommunityUser, BooleanVote, NumberVote
 

--- a/policykit/policyengine/views.py
+++ b/policykit/policyengine/views.py
@@ -695,8 +695,9 @@ def execute_policy(policy, action, is_first_evaluation: bool):
         if check_result == Proposal.PASSED:
             # run "pass" block of policy
             pass_policy(policy, action)
-            # FIXME: Add back this assertion when issue #305 is fixed https://github.com/amyxzhang/policykit/issues/305
-            # assert(action.proposal.status == Proposal.PASSED)
+            # mark action proposal as 'passed'
+            action.pass_action()
+            assert(action.proposal.status == Proposal.PASSED)
 
         elif check_result == Proposal.FAILED:
             # run "fail" block of policy

--- a/policykit/policyengine/views.py
+++ b/policykit/policyengine/views.py
@@ -417,7 +417,6 @@ def pass_policy(policy, action):
 
     wrapper_end = "\r\nsuccess(policy, action, users, metagov)"
 
-    logger.info('policy passed: ' + str(policy.name))
     exec_code(policy.success, wrapper_start, wrapper_end, None, _locals)
 
 def fail_policy(policy, action):
@@ -683,7 +682,7 @@ def execute_policy(policy, action, is_first_evaluation: bool):
     if filter_policy(policy, action):
         from policyengine.models import Proposal
 
-        log_prefix = f"[engine][{policy.name}][action {action.pk}]"
+        log_prefix = f"[{policy}][{action}]"
         logger.info(f"{log_prefix} Passed filter")
 
         # If policy is being evaluated for the first time, initialize it

--- a/policykit/policyengine/views.py
+++ b/policykit/policyengine/views.py
@@ -430,6 +430,7 @@ def fail_policy(policy, action):
     logger.info('policy failed: ' + str(policy.name))
     exec_code(policy.fail, wrapper_start, wrapper_end, None, _locals)
 
+# TODO(https://github.com/amyxzhang/policykit/issues/342) remove this
 def clean_up_proposals(action, executed):
     from policyengine.models import Proposal, PlatformActionBundle
 
@@ -452,7 +453,6 @@ def clean_up_proposals(action, executed):
             p.save()
 
     p = action.proposal
-    # what is going on here
     if executed:
         p.status = Proposal.PASSED
     else:

--- a/policykit/scripts/starterkits.py
+++ b/policykit/scripts/starterkits.py
@@ -6,7 +6,6 @@ from django.contrib.contenttypes.models import ContentType
 from django.contrib.contenttypes.fields import GenericForeignKey
 from polymorphic.models import PolymorphicModel
 from django.core.exceptions import ValidationError
-from policyengine.views import check_policy, filter_policy, initialize_policy, pass_policy, fail_policy, notify_policy
 import urllib
 import json
 from policyengine.models import *

--- a/policykit/scripts/starterkits.py
+++ b/policykit/scripts/starterkits.py
@@ -40,7 +40,6 @@ testing_policy1_slack = GenericPolicy.objects.create(filter = "return True",
                                                    starterkit = testing_starterkit_slack,
                                                    is_constitution = True,
                                                    is_bundled = False,
-                                                   has_notified = False,
                                                    )
 
 testing_policy2_slack = GenericPolicy.objects.create(filter = "return True",
@@ -54,7 +53,6 @@ testing_policy2_slack = GenericPolicy.objects.create(filter = "return True",
                                                    starterkit = testing_starterkit_slack,
                                                    is_constitution = False,
                                                    is_bundled = False,
-                                                   has_notified = False,
                                                    )
 
 testing_policy1_reddit = GenericPolicy.objects.create(filter = "return True",
@@ -68,7 +66,6 @@ testing_policy1_reddit = GenericPolicy.objects.create(filter = "return True",
                                                      starterkit = testing_starterkit_reddit,
                                                      is_constitution = True,
                                                      is_bundled = False,
-                                                     has_notified = False,
                                                      )
 
 testing_policy2_reddit = GenericPolicy.objects.create(filter = "return True",
@@ -82,7 +79,6 @@ testing_policy2_reddit = GenericPolicy.objects.create(filter = "return True",
                                                      starterkit = testing_starterkit_reddit,
                                                      is_constitution = False,
                                                      is_bundled = False,
-                                                     has_notified = False,
                                                      )
 
 testing_policy1_discord = GenericPolicy.objects.create(filter = "return True",
@@ -96,7 +92,6 @@ testing_policy1_discord = GenericPolicy.objects.create(filter = "return True",
                                                       starterkit = testing_starterkit_discord,
                                                       is_constitution = True,
                                                       is_bundled = False,
-                                                      has_notified = False,
                                                       )
 
 testing_policy2_discord = GenericPolicy.objects.create(filter = "return True",
@@ -110,7 +105,6 @@ testing_policy2_discord = GenericPolicy.objects.create(filter = "return True",
                                                       starterkit = testing_starterkit_discord,
                                                       is_constitution = False,
                                                       is_bundled = False,
-                                                      has_notified = False,
                                                       )
 
 testing_policy1_discourse = GenericPolicy.objects.create(filter = "return True",
@@ -124,7 +118,6 @@ testing_policy1_discourse = GenericPolicy.objects.create(filter = "return True",
                                                       starterkit = testing_starterkit_discourse,
                                                       is_constitution = True,
                                                       is_bundled = False,
-                                                      has_notified = False,
                                                       )
 
 testing_policy2_discourse = GenericPolicy.objects.create(filter = "return True",
@@ -138,7 +131,6 @@ testing_policy2_discourse = GenericPolicy.objects.create(filter = "return True",
                                                       starterkit = testing_starterkit_discourse,
                                                       is_constitution = False,
                                                       is_bundled = False,
-                                                      has_notified = False,
                                                       )
 
 testing_base_role_slack = GenericRole.objects.create(role_name = "Testing: Base User", name = "Testing: Base User (Slack)", starterkit = testing_starterkit_slack, is_base_role = True, user_group = "all")
@@ -199,7 +191,6 @@ else:
                                                starterkit = admin_user_starterkit_slack,
                                                is_constitution = True,
                                                is_bundled = False,
-                                               has_notified = False,
                                                )
 
 admin_user_policy2_slack = GenericPolicy.objects.create(filter = "return True",
@@ -213,7 +204,6 @@ admin_user_policy2_slack = GenericPolicy.objects.create(filter = "return True",
                                                starterkit = admin_user_starterkit_slack,
                                                is_constitution = False,
                                                is_bundled = False,
-                                               has_notified = False,
                                                )
 
 admin_user_policy1_reddit = GenericPolicy.objects.create(filter = "return True",
@@ -232,7 +222,6 @@ else:
                                                   starterkit = admin_user_starterkit_reddit,
                                                   is_constitution = True,
                                                   is_bundled = False,
-                                                  has_notified = False,
                                                   )
 
 admin_user_policy2_reddit = GenericPolicy.objects.create(filter = "return True",
@@ -246,7 +235,6 @@ admin_user_policy2_reddit = GenericPolicy.objects.create(filter = "return True",
                                                   starterkit = admin_user_starterkit_reddit,
                                                   is_constitution = False,
                                                   is_bundled = False,
-                                                  has_notified = False,
                                                   )
 
 admin_user_policy1_discord = GenericPolicy.objects.create(filter = "return True",
@@ -265,7 +253,6 @@ else:
                                                   starterkit = admin_user_starterkit_discord,
                                                   is_constitution = True,
                                                   is_bundled = False,
-                                                  has_notified = False,
                                                   )
 
 admin_user_policy2_discord = GenericPolicy.objects.create(filter = "return True",
@@ -279,7 +266,6 @@ admin_user_policy2_discord = GenericPolicy.objects.create(filter = "return True"
                                                      starterkit = admin_user_starterkit_discord,
                                                      is_constitution = False,
                                                      is_bundled = False,
-                                                     has_notified = False,
                                                      )
 
 admin_user_policy1_discourse = GenericPolicy.objects.create(filter = "return True",
@@ -298,7 +284,6 @@ else:
                                                   starterkit = admin_user_starterkit_discourse,
                                                   is_constitution = True,
                                                   is_bundled = False,
-                                                  has_notified = False,
                                                   )
 
 admin_user_policy2_discourse = GenericPolicy.objects.create(filter = "return True",
@@ -312,7 +297,6 @@ admin_user_policy2_discourse = GenericPolicy.objects.create(filter = "return Tru
                                                      starterkit = admin_user_starterkit_discourse,
                                                      is_constitution = False,
                                                      is_bundled = False,
-                                                     has_notified = False,
                                                      )
 
 admin_user_base_role_slack = GenericRole.objects.create(role_name = "Admin and User: Base User", name = "Admin and User: Base User (Slack)", starterkit = admin_user_starterkit_slack, is_base_role = True, user_group = "nonadmins")
@@ -398,7 +382,6 @@ democracy_policy1_slack = GenericPolicy.objects.create(filter = "return True",
                                        starterkit = democracy_starterkit_slack,
                                        is_constitution = False,
                                        is_bundled = False,
-                                       has_notified = False,
                                        )
 
 democracy_policy2_slack = GenericPolicy.objects.create(
@@ -430,7 +413,6 @@ action.community.notify_action(action, policy, users=voter_users, template='Plea
                                        starterkit = democracy_starterkit_slack,
                                        is_constitution = True,
                                        is_bundled = False,
-                                       has_notified = False,
                                        )
 
 democracy_policy1_reddit = GenericPolicy.objects.create(filter = "return True",
@@ -444,7 +426,6 @@ democracy_policy1_reddit = GenericPolicy.objects.create(filter = "return True",
                                                        starterkit = democracy_starterkit_reddit,
                                                        is_constitution = False,
                                                        is_bundled = False,
-                                                       has_notified = False,
                                                        )
 
 democracy_policy2_reddit = GenericPolicy.objects.create(
@@ -476,7 +457,6 @@ action.community.notify_action(action, policy, users=voter_users, template='Plea
                                                        starterkit = democracy_starterkit_reddit,
                                                        is_constitution = True,
                                                        is_bundled = False,
-                                                       has_notified = False,
                                                        )
 
 democracy_policy1_discord = GenericPolicy.objects.create(filter = "return True",
@@ -490,7 +470,6 @@ democracy_policy1_discord = GenericPolicy.objects.create(filter = "return True",
                                                        starterkit = democracy_starterkit_discord,
                                                        is_constitution = False,
                                                        is_bundled = False,
-                                                       has_notified = False,
                                                        )
 
 democracy_policy2_discord = GenericPolicy.objects.create(
@@ -522,7 +501,6 @@ action.community.notify_action(action, policy, users=voter_users, template='Plea
                                                        starterkit = democracy_starterkit_discord,
                                                        is_constitution = True,
                                                        is_bundled = False,
-                                                       has_notified = False,
                                                        )
 
 democracy_policy1_discourse = GenericPolicy.objects.create(filter = "return True",
@@ -536,7 +514,6 @@ democracy_policy1_discourse = GenericPolicy.objects.create(filter = "return True
                                                        starterkit = democracy_starterkit_discourse,
                                                        is_constitution = False,
                                                        is_bundled = False,
-                                                       has_notified = False,
                                                        )
 
 democracy_policy2_discourse = GenericPolicy.objects.create(
@@ -568,7 +545,6 @@ action.community.notify_action(action, policy, users=voter_users, template='Plea
                                                        starterkit = democracy_starterkit_discourse,
                                                        is_constitution = True,
                                                        is_bundled = False,
-                                                       has_notified = False,
                                                        )
 
 democracy_base_role_slack = GenericRole.objects.create(role_name = "Democracy: Base User", name = "Democracy: Base User (Slack)", starterkit = democracy_starterkit_slack, is_base_role = True, user_group = "nonadmins")
@@ -653,7 +629,6 @@ dictator_policy1_slack = GenericPolicy.objects.create(filter = "return True",
                                        starterkit = dictator_starterkit_slack,
                                        is_constitution = True,
                                        is_bundled = False,
-                                       has_notified = False,
                                        )
 
 dictator_policy2_slack = GenericPolicy.objects.create(filter = "return True",
@@ -667,7 +642,6 @@ dictator_policy2_slack = GenericPolicy.objects.create(filter = "return True",
                                        starterkit = dictator_starterkit_slack,
                                        is_constitution = False,
                                        is_bundled = False,
-                                       has_notified = False,
                                        )
 
 dictator_policy1_reddit = GenericPolicy.objects.create(filter = "return True",
@@ -681,7 +655,6 @@ dictator_policy1_reddit = GenericPolicy.objects.create(filter = "return True",
                                                 starterkit = dictator_starterkit_reddit,
                                                 is_constitution = True,
                                                 is_bundled = False,
-                                                has_notified = False,
                                                 )
 
 dictator_policy2_reddit = GenericPolicy.objects.create(filter = "return True",
@@ -695,7 +668,6 @@ dictator_policy2_reddit = GenericPolicy.objects.create(filter = "return True",
                                                 starterkit = dictator_starterkit_reddit,
                                                 is_constitution = False,
                                                 is_bundled = False,
-                                                has_notified = False,
                                                 )
 
 dictator_policy1_discord = GenericPolicy.objects.create(filter = "return True",
@@ -709,7 +681,6 @@ dictator_policy1_discord = GenericPolicy.objects.create(filter = "return True",
                                                 starterkit = dictator_starterkit_discord,
                                                 is_constitution = True,
                                                 is_bundled = False,
-                                                has_notified = False,
                                                 )
 
 dictator_policy2_discord = GenericPolicy.objects.create(filter = "return True",
@@ -723,7 +694,6 @@ dictator_policy2_discord = GenericPolicy.objects.create(filter = "return True",
                                                 starterkit = dictator_starterkit_discord,
                                                 is_constitution = False,
                                                 is_bundled = False,
-                                                has_notified = False,
                                                 )
 
 dictator_policy1_discourse = GenericPolicy.objects.create(filter = "return True",
@@ -737,7 +707,6 @@ dictator_policy1_discourse = GenericPolicy.objects.create(filter = "return True"
                                                 starterkit = dictator_starterkit_discourse,
                                                 is_constitution = True,
                                                 is_bundled = False,
-                                                has_notified = False,
                                                 )
 
 dictator_policy2_discourse = GenericPolicy.objects.create(filter = "return True",
@@ -751,7 +720,6 @@ dictator_policy2_discourse = GenericPolicy.objects.create(filter = "return True"
                                                 starterkit = dictator_starterkit_discourse,
                                                 is_constitution = False,
                                                 is_bundled = False,
-                                                has_notified = False,
                                                 )
 
 dictator_base_role_slack = GenericRole.objects.create(role_name = "Dictator: Base User", name = "Dictator: Base User (Slack)", starterkit = dictator_starterkit_slack, is_base_role = True, user_group = "all")
@@ -853,7 +821,6 @@ action.community.notify_action(action, policy, users=jury_users, template='Pleas
                                        starterkit = jury_starterkit_slack,
                                        is_constitution = True,
                                        is_bundled = False,
-                                       has_notified = False,
                                        )
 
 jury_policy2_slack = GenericPolicy.objects.create(filter = "return True",
@@ -867,7 +834,6 @@ jury_policy2_slack = GenericPolicy.objects.create(filter = "return True",
                                        starterkit = jury_starterkit_slack,
                                        is_constitution = False,
                                        is_bundled = False,
-                                       has_notified = False,
                                        )
 
 jury_policy1_reddit = GenericPolicy.objects.create(filter = "return True",
@@ -897,7 +863,6 @@ action.community.notify_action(action, policy, users=jury_users, template='Pleas
                                        starterkit = jury_starterkit_reddit,
                                        is_constitution = True,
                                        is_bundled = False,
-                                       has_notified = False,
                                        )
 
 jury_policy2_reddit = GenericPolicy.objects.create(filter = "return True",
@@ -911,7 +876,6 @@ jury_policy2_reddit = GenericPolicy.objects.create(filter = "return True",
                                        starterkit = jury_starterkit_reddit,
                                        is_constitution = False,
                                        is_bundled = False,
-                                       has_notified = False,
                                        )
 
 jury_policy1_discord = GenericPolicy.objects.create(filter = "return True",
@@ -941,7 +905,6 @@ action.community.notify_action(action, policy, users=jury_users, template='Pleas
                                        starterkit = jury_starterkit_discord,
                                        is_constitution = True,
                                        is_bundled = False,
-                                       has_notified = False,
                                        )
 
 jury_policy2_discord = GenericPolicy.objects.create(filter = "return True",
@@ -955,7 +918,6 @@ jury_policy2_discord = GenericPolicy.objects.create(filter = "return True",
                                        starterkit = jury_starterkit_discord,
                                        is_constitution = False,
                                        is_bundled = False,
-                                       has_notified = False,
                                        )
 
 jury_policy1_discourse = GenericPolicy.objects.create(filter = "return True",
@@ -985,7 +947,6 @@ action.community.notify_action(action, policy, users=jury_users, template='Pleas
                                        starterkit = jury_starterkit_discourse,
                                        is_constitution = True,
                                        is_bundled = False,
-                                       has_notified = False,
                                        )
 
 jury_policy2_discourse = GenericPolicy.objects.create(filter = "return True",
@@ -999,7 +960,6 @@ jury_policy2_discourse = GenericPolicy.objects.create(filter = "return True",
                                        starterkit = jury_starterkit_discourse,
                                        is_constitution = False,
                                        is_bundled = False,
-                                       has_notified = False,
                                        )
 
 jury_base_role_slack = GenericRole.objects.create(role_name = "Jury: Base User", name = "Jury: Base User (Slack)", starterkit = jury_starterkit_slack, is_base_role = True, user_group = "all")

--- a/policykit/tests/test_policy_evaluation.py
+++ b/policykit/tests/test_policy_evaluation.py
@@ -74,9 +74,7 @@ return FAILED
         process = ExternalProcess.objects.filter(action=action, policy=policy).first()
         self.assertIsNotNone(process)
 
-        # Fails because of bug https://github.com/amyxzhang/policykit/issues/305
-        # self.assertEqual(action.proposal.status, "passed")
-
+        self.assertEqual(action.proposal.status, "passed")
         self.assertEqual(action.data.get("status"), "completed")
         self.assertIsNotNone(action.data.get("outcome").get("winner"))
 
@@ -159,7 +157,7 @@ if response and response.get('value') == 4:
     return PASSED
 return FAILED"""
         policy.notify = "pass"
-        policy.success = "action.execute()"  # Needed to mark as "passed" because of bug https://github.com/amyxzhang/policykit/issues/305
+        policy.success = "pass"
         policy.fail = "pass"
         policy.description = "test"
         policy.name = "test policy"
@@ -193,7 +191,7 @@ and action.event_type == 'discourse.post_created'"""
         policy.initialize = "action.data.set('test_verify_username', action.initiator.metagovuser.external_username)"
         policy.notify = "pass"
         policy.check = "return PASSED if action.event_data['category'] == 0 else FAILED"
-        policy.success = "action.execute()"  # Needed to mark as "passed" because of bug https://github.com/amyxzhang/policykit/issues/305
+        policy.success = "pass"
         policy.fail = "pass"
         policy.description = "test"
         policy.name = "test policy"


### PR DESCRIPTION
![Screen Shot 2021-03-05 at 16 11 22](https://user-images.githubusercontent.com/5333982/110174783-a7fc5900-7dce-11eb-86c1-6ef2cd479ee5.png)


The logic in the diagram is repeated in 10+ different places in the codebase, and with slight variations and side effects. Policy authors need to rely on a specific sequence of evaluation for policies, so I think we should make this consistent and define it in one place. It will also make debugging a lot easier.

**This moves policy evaluation to a single function called `execute_policy`**.


#### Testing
- [x] Discourse: test a policy that governs creating a topic on Discourse (Note: Discourse integrator doesn't support reverting+Executing actions https://github.com/amyxzhang/policykit/issues/335, but I tested what functionality does exist, and I don't think I'm introducing any new bugs.)
- [x] ~~Discourse: test a policy that votes on a PlatformAction~~ the Discourse integrator doesn't support this yet
- [x] Discord: test a policy that votes on a PlatformAction
- [x] Slack: test a policy that votes on a PlatformAction
- [x] ~~Discourse: test a policy bundle~~ bundles not implemented
- [x] ~~Discord: test a policy bundle~~ bundles not implemented
- [x] ~~Slack: test a policy bundle~~ bundles not implemented