### PR TITLE
Support policies that are triggered by Metagov events

### DIFF
--- a/policykit/integrations/metagov/models.py
+++ b/policykit/integrations/metagov/models.py
@@ -1,5 +1,13 @@
+import json
+import logging
+
+from django.contrib.auth.models import ContentType, Permission, User
 from django.db import models
-from policyengine.models import PlatformAction, PlatformPolicy
+from policyengine.models import (Community, CommunityRole, CommunityUser,
+                                 ConstitutionPolicy, PlatformAction,
+                                 PlatformPolicy, Proposal, StarterKit)
+
+logger = logging.getLogger(__name__)
 
 
 class ExternalProcess(models.Model):
@@ -9,10 +17,47 @@ class ExternalProcess(models.Model):
     action = models.ForeignKey(PlatformAction, on_delete=models.CASCADE)
 
     class Meta:
-        unique_together = ['policy', 'action']
+        unique_together = ["policy", "action"]
 
-# TODO add generic integrator models, so that Metagov can act as a connector for various external platforms
-# ExternalCommunity
-# ExternalUser
-# ExternalPlatformAction]
 
+class MetagovUser(CommunityUser):
+    provider = models.CharField(max_length=30, help_text="Identity provider that the username comes from")
+    """
+    Represents a user in the MetagovCommunity, which could be on any platform.
+    """
+
+    # Hack so it doesn't clash with usernames from other communities (django User requires unique username).
+    # TODO(#299): make the CommunityUser model unique on community+username, not just username.
+    def get_real_username(self):
+        prefix = f"{self.provider}."
+        if self.username.startswith(prefix):
+            return self.username[len(prefix) :]
+        return self.username
+
+
+class MetagovPlatformAction(PlatformAction):
+    """
+    This is a PlatformAction model to use as a policy trigger for events received from Metagov.
+    It does not represent a "governable" action, because `revert` and `execute` are not implemented (for now).
+    Data about the event is stored as a json blob in the `json_data` field.
+    """
+
+    action_codename = "metagovaction"
+    app_name = "metagov"
+    json_data = models.CharField(max_length=500, blank=True, null=True)
+    event_type = models.CharField(max_length=50, blank=True, null=True)
+
+    def __str__(self):
+        return str(self.event_type)
+
+    def get_metagov_action_data(self):
+        if self.json_data:
+            return json.loads(self.json_data)
+        return None
+
+    def execute(self):
+        # because of https://github.com/amyxzhang/policykit/issues/305
+        self.pass_action()
+
+    def revert(self):
+        pass

--- a/policykit/integrations/metagov/views.py
+++ b/policykit/integrations/metagov/views.py
@@ -4,14 +4,15 @@ import logging
 import requests
 from django.conf import settings
 from django.contrib.auth import get_user
+from django.contrib.auth.models import ContentType, Permission
 from django.contrib.auth.decorators import login_required
 from django.core.exceptions import PermissionDenied
 from django.http import HttpResponse, HttpResponseBadRequest
 from django.shortcuts import render
 from django.views.decorators.csrf import csrf_exempt
 from integrations.metagov.library import metagov_slug, update_metagov_community
-from integrations.metagov.models import ExternalProcess
-from policyengine.models import Community
+from integrations.metagov.models import ExternalProcess, MetagovUser, MetagovPlatformAction
+from policyengine.models import Community, CommunityRole
 
 logger = logging.getLogger(__name__)
 
@@ -86,12 +87,65 @@ def post_outcome(request, id):
 
 @csrf_exempt
 def action(request):
-    if request.method != 'POST' or not request.body:
+    """
+    Receive event from Metagov, and create a new MetagovPlatformAction.
+
+    1) Find the `Community` that this metagov community corresponds to (e.g. the SlackCommunity that was configured to use Metagov.)
+    2) Get or create a MetagovUser that' stied to the original community (the SlackCommunity)
+    3) Give the user permission to propose MetagovPlatformActions
+    """
+
+    if request.method != "POST" or not request.body:
         return HttpResponseBadRequest()
     try:
         body = json.loads(request.body)
     except ValueError:
         return HttpResponseBadRequest("unable to decode body")
-    logger.info(f"Received external action: {body}")
-    # TODO create ExternalPlatformAction
+    logger.info(f"Received metagov action: {body}")
+
+    metagov_community_slug = body.get("community")
+
+    try:
+        community = Community.objects.get_by_metagov_name(name=metagov_community_slug)
+    except Community.DoesNotExist:
+        logger.error(f"Received event for community {metagov_community_slug} which doesn't exist in PolicyKit")
+        return HttpResponseBadRequest("Community does not exist")
+
+    # Hack so MetagovUser username doesn't clash with usernames from other communities (django User requires unique username).
+    # TODO(#299): make the CommunityUser model unique on community+username, not just username.
+    initiator = body["initiator"]
+    prefixed_username = f"{initiator['provider']}.{initiator['user_id']}"
+    metagov_user, _ = MetagovUser.objects.get_or_create(
+        username=prefixed_username, provider=initiator["provider"], community=community
+    )
+
+    # Give this user permission to propose any MetagovPlatformAction
+    user_group, usergroup_created = CommunityRole.objects.get_or_create(
+        role_name="Base User", name=f"Metagov: {metagov_community_slug}: Base User"
+    )
+    if usergroup_created:
+        user_group.community = community
+        content_type = ContentType.objects.get_for_model(MetagovPlatformAction)
+        permission, _ = Permission.objects.get_or_create(
+            codename="add_metagovaction",
+            name="Can add metagov action",
+            content_type=content_type,
+        )
+        user_group.permissions.add(permission)
+        user_group.save()
+    user_group.user_set.add(metagov_user)
+
+    # Create MetagovPlatformAction
+    new_api_action = MetagovPlatformAction()
+    new_api_action.community = community
+    new_api_action.initiator = metagov_user
+    new_api_action.event_type = body["event_type"]
+    new_api_action.json_data = json.dumps(body["data"])
+
+    # Save to create Proposal and trigger PlatformPolicy evaluations
+    new_api_action.save()
+    if not new_api_action.pk:
+        return HttpResponseServerError()
+
+    logger.info(f"Created new MetagovPlatformAction with pk {new_api_action.pk}")
     return HttpResponse()

--- a/policykit/policyengine/filter.py
+++ b/policykit/policyengine/filter.py
@@ -324,7 +324,10 @@ policyengine_functions = [
     'remove',
     'set',
     'get_roles',
-    'has_role'
+    'has_role',
+    # metagov model functions
+    'get_metagov_action_data',
+    'get_real_username'
 ]
 
 # Don't whitelist any string functions that allow for format string vulnerabilities

--- a/policykit/tests/test_policy_evaluation.py
+++ b/policykit/tests/test_policy_evaluation.py
@@ -1,35 +1,89 @@
 import json
+from unittest import skip
 
+import requests
 from django.contrib.auth.models import Permission
-from django.test import TestCase
-from integrations.metagov.models import ExternalProcess
-from integrations.slack.models import (SlackCommunity, SlackPinMessage,
-                                       SlackStarterKit, SlackUser)
-from policyengine.models import (CommunityRole, PlatformAction, PlatformPolicy,
-                                 Proposal)
-from policyengine.views import check_policy
+from django.test import Client, TestCase
+from integrations.metagov.library import update_metagov_community, metagov_slug
+from integrations.metagov.models import ExternalProcess, MetagovPlatformAction, MetagovUser
+from integrations.slack.models import SlackCommunity, SlackPinMessage, SlackStarterKit, SlackUser
+from policyengine.models import CommunityRole, PlatformAction, PlatformPolicy, Proposal
+from policyengine.views import check_policy, filter_policy
 
-"""
-FIXME: mock metagov service
-"""
+METAGOV_URL = "http://127.0.0.1:8000"
 
 
 class EvaluationTests(TestCase):
     def setUp(self):
-        user_group = CommunityRole.objects.create(
-            role_name="fake role", name="testing role")
+        # Set up a Slack community and a user
+        user_group = CommunityRole.objects.create(role_name="fake role", name="testing role")
         p1 = Permission.objects.get(name="Can add slack pin message")
         user_group.permissions.add(p1)
         self.community = SlackCommunity.objects.create(
-            community_name='my test community',
-            team_id='TMQ3PKX',
-            bot_id='test',
-            access_token='test',
-            base_role=user_group)
-        self.user = SlackUser.objects.create(
-            username="test", community=self.community)
+            community_name="my test community",
+            team_id="TMQ3PKX",
+            bot_id="test",
+            access_token="test",
+            base_role=user_group,
+        )
+        self.user = SlackUser.objects.create(username="test", community=self.community)
 
-    def test_external_process(self):
+        # Activate a plugin to use in tests
+        update_metagov_community(
+            community=self.community,
+            plugins=list(
+                [
+                    {"name": "randomness", "config": {"default_low": 2, "default_high": 200}},
+                ]
+            ),
+        )
+
+    def test_close_process(self):
+        # 1) Create Policy and PlatformAction
+        policy = PlatformPolicy()
+        policy.community = self.community
+        policy.filter = "return True"
+        policy.initialize = """
+metagov.start_process("randomness.delayed-stochastic-vote", {"options": ["one", "two", "three"], "delay": 1})
+"""
+        policy.notify = ""
+        policy.check = """
+result = metagov.close_process()
+action.data.set('status', result.status)
+action.data.set('outcome', result.outcome)
+
+if result is None:
+    return #still processing
+if result.errors:
+    return FAILED
+if result.outcome:
+    return PASSED if result.outcome.get('winner') else FAILED
+return FAILED
+"""
+        policy.success = "pass"
+        policy.fail = "pass"
+        policy.description = "test"
+        policy.name = "test policy"
+        policy.save()
+
+        action = SlackPinMessage()
+        action.initiator = self.user
+        action.community = self.community
+
+        # 2) Save action to trigger policy execution
+        action.save()
+
+        process = ExternalProcess.objects.filter(action=action, policy=policy).first()
+        self.assertIsNotNone(process)
+
+        # Fails because of bug https://github.com/amyxzhang/policykit/issues/305
+        # self.assertEqual(action.proposal.status, "passed")
+
+        self.assertEqual(action.data.get("status"), "completed")
+        self.assertIsNotNone(action.data.get("outcome").get("winner"))
+
+    @skip("Don't run loomio vote test because it requires an API key")
+    def test_loomio_vote(self):
         print("\nTesting external process\n")
         # 1) Create Policy and PlatformAction
         policy = PlatformPolicy()
@@ -103,11 +157,13 @@ return FAILED
         policy.community = self.community
         policy.filter = "return True"
         policy.initialize = "pass"
-        policy.check = """response = metagov.get_resource('sourcecred.cred', { 'username': 'miriam' })\n
-cred = response.get('value')\n
-return PASSED if cred > 0.5 else FAILED"""
-        policy.notify = """pass"""
-        policy.success = "pass"
+        policy.check = """parameters = {"low": 4, "high": 5}
+response = metagov.get_resource('randomness.random-int', parameters)
+if response and response.get('value') == 4:
+    return PASSED
+return FAILED"""
+        policy.notify = "pass"
+        policy.success = "action.execute()"  # Needed to mark as "passed" because of bug https://github.com/amyxzhang/policykit/issues/305
         policy.fail = "pass"
         policy.description = "test"
         policy.name = "test policy"
@@ -117,8 +173,59 @@ return PASSED if cred > 0.5 else FAILED"""
         action.initiator = self.user
         action.community = self.community
 
-        # 2) Save action to trigger execution of check() and notify()
+        # 2) Save action to trigger policy execution
         action.save()
 
-        result = check_policy(policy, action)
-        self.assertEqual(result, 'passed')
+        self.assertEqual(action.proposal.status, "passed")
+
+
+class MetagovPlatformActionTest(TestCase):
+    def setUp(self):
+        user_group = CommunityRole.objects.create(role_name="fake role", name="testing role")
+        p1 = Permission.objects.get(name="Can add slack pin message")
+        user_group.permissions.add(p1)
+        self.community = SlackCommunity.objects.create(
+            community_name="test community", team_id="test123", bot_id="test", access_token="test", base_role=user_group
+        )
+
+    def test_metagov_trigger(self):
+        # 1) Create Policy that is triggered by a metagov action
+
+        policy = PlatformPolicy()
+        policy.community = self.community
+        policy.filter = """return action.action_codename == 'metagovaction' \
+and action.event_type == 'discourse_post_created'"""
+        policy.initialize = "action.data.set('test_verify_username', action.initiator.metagovuser.get_real_username())"
+        policy.notify = "pass"
+        policy.check = "return PASSED if action.get_metagov_action_data()['category'] == 0 else FAILED"
+        policy.success = "action.execute()"  # Needed to mark as "passed" because of bug https://github.com/amyxzhang/policykit/issues/305
+        policy.fail = "pass"
+        policy.description = "test"
+        policy.name = "test policy"
+        policy.save()
+
+
+        event_payload = {
+            "community": metagov_slug(self.community),
+            "initiator": {"user_id": "miriam", "provider": "discourse"},
+            "event_type": "discourse_post_created",
+            "data": {"title": "test", "raw": "post text", "category": 0},
+        }
+
+        # 2) Mimick an incoming notification from Metagov that the action has occurred
+        client = Client()
+        response = client.post(f"/metagov/action", data=event_payload, content_type="application/json")
+
+        self.assertEqual(response.status_code, 200)
+
+        self.assertEqual(MetagovPlatformAction.objects.all().count(), 1)
+
+        action = MetagovPlatformAction.objects.filter(event_type="discourse_post_created").first()
+
+        self.assertEqual(action.community.platform, "slack") ## the action.community is the community that is connected to metagov
+        self.assertEqual(action.initiator.username, "discourse.miriam")
+        self.assertEqual(action.initiator.metagovuser.get_real_username(), "miriam")
+        self.assertEqual(action.data.get("test_verify_username"), "miriam")
+        self.assertEqual(action.get_metagov_action_data()["raw"], "post text")
+
+        self.assertEqual(action.proposal.status, "passed")


### PR DESCRIPTION
With this change, a Policy author can specify an event defined in a Metagov plugin as a policy trigger. Example `filter` block: 

    ```
    return action.action_codename == 'metagovaction' and action.event_type == 'opencollective_expense_created'
    ```


#### How this works:

> Pre-requirement: there is a SlackCommunity (or whatever Community) that has already been configured to enable some Metagov plugin that sends events.

1. Metagov makes a POST request to the PolicyKit endpoint `/metagov/action` with a payload that looks like:
   ```js
       {
            "community": "slack-test123",   # Unique string identifying the community that this action "belongs" to. It was originally defined by PolicyKit.
            "initiator": {"user_id": "miriam", "provider": "discourse"},
            "event_type": "discourse_post_created",
            "data": {"title": "test", "raw": "post text", "category": 0},
        }
   ```
2. The `integrations.metagov` app in PolicyKit creates a `MetagovPlatformAction` for this event.
    * The `action.initiator` is set to a `MetagovUser` which has blanket access to "propose" any MetagovPlatformAction in this community.
    * The `action.community` is set to the _original community in PolicyKit_ (in this example, the `SlackCommunity`).

    > The `MetagovPlatformAction` does not support `execute` or `revert` functionality. It is simply a trigger event. In order to support execution/reversion of actions, we'd need to create individual subclasses of MetagovPlatformAction for each action (eg `OpenCollectiveConversation`, `DiscoursePost`, etc.)
3. When the newly created `MetagovPlatformAction` event is saved, it triggers a policy evaluation. The [logic is](https://github.com/amyxzhang/policykit/blob/c5569bf20aec47c9f69176a536d0e23879308beb/policykit/policyengine/models.py#L799) to execute all policies where `PlatformPolicy.objects.filter(community=action.community)`. That means any PlatformPolicy that is defined for this SlackCommunity will be tested.
    > That means Slack policies with `filter: return True` will execute for metagov actions too, which is maybe not what we want? I don't know how those blanket policies are really used.