### PR TITLE
Support closing a metagov process from a policy

### DIFF
--- a/policykit/integrations/metagov/models.py
+++ b/policykit/integrations/metagov/models.py
@@ -3,6 +3,7 @@ from policyengine.models import PlatformAction, PlatformPolicy
 
 
 class ExternalProcess(models.Model):
+    location = models.CharField(max_length=100, blank=True)
     json_data = models.CharField(max_length=500, blank=True, null=True)
     policy = models.ForeignKey(PlatformPolicy, on_delete=models.CASCADE)
     action = models.ForeignKey(PlatformAction, on_delete=models.CASCADE)

--- a/policykit/policyengine/filter.py
+++ b/policykit/policyengine/filter.py
@@ -42,6 +42,7 @@ whitelisted_builtins = [
 whitelisted_modules = {
     "metagov": [
         "start_process",
+        "close_process",
         "get_process_outcome",
         "get_resource",
     ],


### PR DESCRIPTION
Let policy authors "close" an existing governance process by invoking `DELETE /api/internal/process/<process_name>/<process_id>`.

The plugin author implements "close" if they want to expose a way for Metagov/Driver to close or cancel a governance process manually. In some cases it will not be implemented, because the plugin just notifies the Driver when the process is completed––without giving Metagov a way to cancel it manually (Loomio plugin works like this).

In the `discourse-poll` process I'm using,  the "close" function closes the poll in discourse, locks the post, and returns the vote outcome. Here's an example usage of that process from a Platform Policy:

```py
# NOTIFY
parameters = {"title": "Should this post be pinned?", "options": ["yes", "no"], "category": 8}
result = metagov.start_process("discourse-poll", parameters)
poll_url = result.get('poll_url')
# Elided: notify users of the poll
```
```py
# CHECK
import datetime
if action.proposal.time_elapsed() < datetime.timedelta(minutes=5):
  return None #still processing

result = metagov.close_process()

if result.errors:
  return FAILED
if result.outcome:
  agree_count = result.outcome.get('yes')
  disagree_count = result.outcome.get('no')
  return PASSED if agree_count > disagree_count else FAILED

return FAILED
```