### PR TITLE
Revert "Bump django from 3.0.7 to 3.1.6 in /policykit"

### DIFF
--- a/policykit/requirements.txt
+++ b/policykit/requirements.txt
@@ -8,7 +8,7 @@ celery==4.4.0
 certifi==2019.11.28
 chardet==3.0.4
 decorator==4.4.1
-Django==3.1.6
+Django==3.0.7
 django-activity-stream==0.9.0
 django-celery-beat==1.5.0
 django-celery-results==1.1.2


### PR DESCRIPTION
Reverts amyxzhang/policykit#307

Revert until we can look through dependencies and also upgrade them to be compatible.