### PR TITLE
Support multiple Metagov communities, add config view to edit them

### DIFF
--- a/policykit/integrations/metagov/templates/config.html
+++ b/policykit/integrations/metagov/templates/config.html
@@ -46,7 +46,7 @@
   <form class="form-horizontal editor">
     <div class="form-row">
         <div class="col-sm-12">
-          <textarea class="form-control code" id="config" required rows="30"></textarea>
+          <textarea class="form-control code" id="config" required rows="5"></textarea>
         </div>
       </div>
     <div class="form-row">

--- a/policykit/integrations/metagov/templates/config.html
+++ b/policykit/integrations/metagov/templates/config.html
@@ -1,0 +1,142 @@
+{% extends "./policyadmin/dashboard/dashboard_base.html" %}
+{% load static %}
+
+{% block styles %}
+<link rel="stylesheet" href="{% static "codemirror/lib/codemirror.css" %}">
+
+<style>
+  .body {
+    min-height: 90vh;
+    margin: 0 10vw;
+    padding-top: 3vh;
+  }
+
+  .editor {
+    padding-top: 3vh;
+    width: 100%;
+  }
+
+  .code {
+    resize: none;
+  }
+
+  .error {
+      color: red
+  }
+  .CodeMirror {
+    height: auto;
+    width: 100%;
+    border: 1px solid #000000;
+  }
+
+  .form-row {
+    margin-bottom: 20px;
+  }
+
+  .btn {
+    font-size: 1.2em;
+  }
+</style>
+{% endblock %}
+
+{% block content %}
+<div class="body">
+  <h3>Metagov Configuration</h3>
+
+  <form class="form-horizontal editor">
+    <div class="form-row">
+        <div class="col-sm-12">
+          <textarea class="form-control code" id="config" required rows="30"></textarea>
+        </div>
+      </div>
+    <div class="form-row">
+      <div class="col-sm-12">
+        <button type="button" class="btn btn-success" id="save">Save</button>
+      </div>
+    </div>
+    <div class="form-row">
+        <div class="col-sm-12">
+          <div id="alerts"></div>
+        </div>
+      </div>
+  </form>
+
+</div>
+
+{% endblock %}
+
+{% block scripts %}
+<script src={% static "codemirror/lib/codemirror.js" %}></script>
+<script src={% static "codemirror/lib/codemirror.css" %}></script>
+<script src={% static "codemirror/addon/hint/show-hint.js" %}></script>
+<script src={% static "codemirror/addon/hint/show-hint.css" %}></script>
+<script src={% static "codemirror/addon/display/autorefresh.js" %}></script>
+<script src={% static "codemirror/addon/hint/show-hint.css" %}></script>
+<script src={% static "codemirror/addon/hint/css-hint.js" %}></script>
+
+
+<script>
+  document.getElementById("save").addEventListener("click", save);
+
+function save() {
+    const errorContainer = document.getElementById('alerts')
+    errorContainer.innerHTML = ''
+    function showError(message) {
+        const errorMsg = document.createElement('div')
+        errorMsg.classList.add('error')
+        errorMsg.innerHTML = message
+        errorContainer.appendChild(errorMsg)
+    }
+
+    const configString = document.getElementById("config").nextSibling.CodeMirror.getValue()
+    let jsonObject = {};
+    try {
+        jsonObject = JSON.parse(configString);
+    } catch (err) {
+        console.error(err)
+        showError("Invalid JSON");
+        return;
+    }
+
+    fetch('../../../metagov/save_config', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify(jsonObject)
+    }).then(response => {
+      if (!response.ok) {
+        response.text().then(text => {
+            const errorMsg = document.createElement('div')
+            errorMsg.classList.add('error')
+            errorMsg.innerHTML = text
+            errorContainer.appendChild(errorMsg)
+        })
+      } else {
+        window.location.href = "{{server_url}}/main/"
+      }
+    })
+  }
+
+  // https://stackoverflow.com/questions/7394748/whats-the-right-way-to-decode-a-string-that-has-special-html-entities-in-it
+  function decodeHtml(html) {
+    var txt = document.createElement("textarea");
+    txt.innerHTML = html;
+    return txt.value;
+  }
+
+  var textArea = document.getElementById("config");
+  const editor = CodeMirror.fromTextArea(textArea, {
+        mode: 'json',
+        autoRefresh: true,
+        lineNumbers: true,
+        theme: 'eclipse',
+        gutters: ['warnings'],
+        extraKeys: {"Ctrl-Space": "autocomplete"},
+        matchBrackets: true,
+        gutters: ['warnings']
+    });
+
+  editor.setValue(decodeHtml(`{{config}}`))
+</script>
+{% endblock %}

--- a/policykit/integrations/metagov/urls.py
+++ b/policykit/integrations/metagov/urls.py
@@ -5,5 +5,7 @@ from integrations.metagov import views
 
 urlpatterns = [
     path('outcome/<int:id>', views.post_outcome),
+    path('config', views.config_editor),
+    path('save_config', views.save_config),
     path('action', views.action),
 ]

--- a/policykit/integrations/metagov/views.py
+++ b/policykit/integrations/metagov/views.py
@@ -5,6 +5,7 @@ import requests
 from django.conf import settings
 from django.contrib.auth import get_user
 from django.contrib.auth.decorators import login_required
+from django.core.exceptions import PermissionDenied
 from django.http import HttpResponse, HttpResponseBadRequest
 from django.shortcuts import render
 from django.views.decorators.csrf import csrf_exempt
@@ -18,6 +19,9 @@ logger = logging.getLogger(__name__)
 @login_required(login_url='/login')
 def config_editor(request):
     user = get_user(request)
+    if not user.is_community_admin:
+        raise PermissionDenied
+
     community = user.community
     url = f"{settings.METAGOV_URL}/api/internal/community/{metagov_slug(community)}"
     response = requests.get(url)

--- a/policykit/integrations/metagov/views.py
+++ b/policykit/integrations/metagov/views.py
@@ -1,11 +1,59 @@
 import json
 import logging
 
+import requests
+from django.conf import settings
+from django.contrib.auth import get_user
+from django.contrib.auth.decorators import login_required
 from django.http import HttpResponse, HttpResponseBadRequest
+from django.shortcuts import render
 from django.views.decorators.csrf import csrf_exempt
+from integrations.metagov.library import metagov_slug, update_metagov_community
 from integrations.metagov.models import ExternalProcess
+from policyengine.models import Community
 
 logger = logging.getLogger(__name__)
+
+
+@login_required(login_url='/login')
+def config_editor(request):
+    user = get_user(request)
+    community = user.community
+    url = f"{settings.METAGOV_URL}/api/internal/community/{metagov_slug(community)}"
+    response = requests.get(url)
+    if not response.ok:
+        if response.status_code == 404:
+            logger.info(
+                f"No metagov community for {community.community_name}, creating for the first time")
+            config = update_metagov_community(community)
+        else:
+            raise Exception(response.text)
+    else:
+        config = response.json()
+
+    pretty_config = json.dumps(config, indent=4, separators=(',', ': '))
+    return render(request, 'config.html', {'config': pretty_config})
+
+
+@csrf_exempt
+def save_config(request):
+    user = get_user(request)
+    community = user.community
+    data = json.loads(request.body)
+
+    if data.get("name") != metagov_slug(community):
+        return HttpResponseBadRequest("Changing the name is not permitted")
+    if data.get("readable_name") != community.community_name:
+        return HttpResponseBadRequest("Changing the readable_name is not permitted")
+
+    logger.info(data.get("plugins"))
+    try:
+        update_metagov_community(community, data.get("plugins", []))
+    except Exception as e:
+        return HttpResponseBadRequest(e)
+
+    return HttpResponse()
+
 
 @csrf_exempt
 def post_outcome(request, id):

--- a/policykit/policyengine/models.py
+++ b/policykit/policyengine/models.py
@@ -50,6 +50,14 @@ class Community(PolymorphicModel):
     def get_users(self, users):
       return users
 
+    def save(self, *args, **kwargs):
+        if not self.pk:
+            # Create a corresponding community in Metagov
+            from integrations.metagov.library import update_metagov_community
+            update_metagov_community(self)
+
+        super(Community, self).save(*args, **kwargs)
+
 class CommunityRole(Group):
     community = models.ForeignKey(Community, models.CASCADE, null=True)
     role_name = models.TextField('readable_name', max_length=300, null=True)

--- a/policykit/tests/test_policy_evaluation.py
+++ b/policykit/tests/test_policy_evaluation.py
@@ -21,8 +21,8 @@ class EvaluationTests(TestCase):
         p1 = Permission.objects.get(name="Can add slack pin message")
         user_group.permissions.add(p1)
         self.community = SlackCommunity.objects.create(
-            community_name='test',
-            team_id='test',
+            community_name='my test community',
+            team_id='TMQ3PKX',
             bot_id='test',
             access_token='test',
             base_role=user_group)
@@ -37,7 +37,7 @@ class EvaluationTests(TestCase):
         policy.filter = "return True"
         policy.initialize = "pass"
         policy.notify = """
-result = metagov.start_process("loomio", {"closing_at": "2021-05-11"})
+result = metagov.start_process("loomio.poll", {"closing_at": "2021-05-11", "title":"test","options":["a","b"]})
 poll_url = result.get('poll_url')
 action.data.set('poll_url', poll_url)
 """
@@ -103,7 +103,7 @@ return FAILED
         policy.community = self.community
         policy.filter = "return True"
         policy.initialize = "pass"
-        policy.check = """response = metagov.get_resource('cred', { 'username': 'miriam' })\n
+        policy.check = """response = metagov.get_resource('sourcecred.cred', { 'username': 'miriam' })\n
 cred = response.get('value')\n
 return PASSED if cred > 0.5 else FAILED"""
         policy.notify = """pass"""


### PR DESCRIPTION
1) When a Community is created for the first time, automatically create a community in Metagov with the unique ID `{community.platform}-{community.team_id}`. By default, no plugins are enabled
2) Community admins can navigate to https://policykit.metagov.org/metagov/config to see the current Metagov config and update it. This is what the page looks like (config blocked out because it contains keys). The editor does validation on the config schema and presents error messages in the UI. Users who are not community admins get a 403.

![Screen Shot 2021-03-26 at 11 20 32](https://user-images.githubusercontent.com/5333982/112654100-6f77fa00-8e25-11eb-9588-5274f39d47e6.png)

Related: https://github.com/metagov/metagov-prototype/pull/11