### PR TITLE
Add PolymorphicUserManager to get rid of warnings #270

### DIFF
--- a/policykit/policyengine/models.py
+++ b/policykit/policyengine/models.py
@@ -2,7 +2,7 @@ from django.db import models, transaction
 from django.db.models.signals import post_save
 from actstream import action
 from django.dispatch import receiver
-from django.contrib.auth.models import User, Group, Permission
+from django.contrib.auth.models import UserManager, User, Group, Permission
 from django.contrib.contenttypes.models import ContentType
 from django.contrib.contenttypes.fields import GenericForeignKey
 from polymorphic.models import PolymorphicModel
@@ -81,12 +81,18 @@ class CommunityRole(Group):
     def __str__(self):
         return str(self.role_name)
 
+class PolymorphicUserManager(UserManager, PolymorphicManager):
+    # no-op class to get rid of warnings (issue #270)
+    pass
+
 class CommunityUser(User, PolymorphicModel):
     readable_name = models.CharField('readable_name', max_length=300, null=True)
     community = models.ForeignKey(Community, models.CASCADE)
     access_token = models.CharField('access_token', max_length=300, null=True)
     is_community_admin = models.BooleanField(default=False)
     avatar = models.CharField('avatar', max_length=500, null=True)
+
+    objects = PolymorphicUserManager()
 
     def __str__(self):
         return self.readable_name if self.readable_name else self.username

--- a/policykit/policyengine/models.py
+++ b/policykit/policyengine/models.py
@@ -5,7 +5,7 @@ from django.dispatch import receiver
 from django.contrib.auth.models import UserManager, User, Group, Permission
 from django.contrib.contenttypes.models import ContentType
 from django.contrib.contenttypes.fields import GenericForeignKey
-from polymorphic.models import PolymorphicModel
+from polymorphic.models import PolymorphicModel, PolymorphicManager
 from django.core.exceptions import ValidationError
 from policyengine.views import check_policy, filter_policy, initialize_policy, pass_policy, fail_policy, notify_policy
 from datetime import datetime, timezone


### PR DESCRIPTION
These warnings come up each time you start up the app https://github.com/amyxzhang/policykit/issues/270
Just adding a no-op manager that inherits from both UserManager and PolymorphicManager to get rid of the warnings.