### PR TITLE
Support performing metagov actions from policies

### DIFF
--- a/policykit/integrations/metagov/library.py
+++ b/policykit/integrations/metagov/library.py
@@ -19,11 +19,7 @@ def metagov_slug(community: Community):
 
 def update_metagov_community(community: Community, plugins=[]):
     metagov_name = metagov_slug(community)
-    payload = {
-        'name': metagov_name,
-        'readable_name': community.community_name,
-        'plugins': plugins
-    }
+    payload = {"name": metagov_name, "readable_name": community.community_name, "plugins": plugins}
     url = f"{settings.METAGOV_URL}/api/internal/community/{metagov_name}"
     response = requests.put(url, json=payload)
     if not response.ok:
@@ -34,9 +30,9 @@ def update_metagov_community(community: Community, plugins=[]):
 
 class DecisionResult(object):
     def __init__(self, obj):
-        self.status = obj.get('status')
-        self.errors = obj.get('errors')
-        self.outcome = obj.get('outcome')
+        self.status = obj.get("status")
+        self.errors = obj.get("errors")
+        self.outcome = obj.get("outcome")
 
 
 class Metagov:
@@ -47,28 +43,22 @@ class Metagov:
     def __init__(self, policy, action):
         self.policy = policy
         self.action = action
-        self.headers = {'X-Metagov-Community': metagov_slug(policy.community)}
+        self.headers = {"X-Metagov-Community": metagov_slug(policy.community)}
 
     def start_process(self, process_name, payload):
         """
         Kick off a governance process in metagov, and pass along a callback_url to
         be invoked whent the process completes.
         """
-        model = ExternalProcess.objects.create(
-            policy=self.policy,
-            action=self.action
-        )
-        url = f"{settings.METAGOV_URL}/api/internal/process/{process_name}"
-        payload['callback_url'] = f"{settings.SERVER_URL}/metagov/outcome/{model.pk}"
-        logger.info(
-            f"Making request to start '{process_name}' with payload: {payload}")
+        model = ExternalProcess.objects.create(policy=self.policy, action=self.action)
 
+        url = f"{settings.METAGOV_URL}/api/internal/process/{process_name}"
+        payload["callback_url"] = f"{settings.SERVER_URL}/metagov/outcome/{model.pk}"
+        logger.info(f"Making request to start '{process_name}' with payload: {payload}")
         response = requests.post(url, json=payload, headers=self.headers)
         if not response.ok:
-            raise Exception(
-                f"Error starting process: {response.status_code} {response.reason} {response.text}")
-
-        location = response.headers.get('location')
+            raise Exception(f"Error starting process: {response.status_code} {response.reason} {response.text}")
+        location = response.headers.get("location")
         if not location:
             raise Exception("Response missing location header")
         model.location = location
@@ -77,37 +67,34 @@ class Metagov:
         resource_url = f"{settings.METAGOV_URL}{location}"
         response = requests.get(resource_url)
         if not response.ok:
-            logger.error(
-                f"Error getting process data: {response.status_code} {response.text}")
-            return None  # FIXME handle
+            raise Exception(f"Error getting process data: {response.status_code} {response.reason} {response.text}")
         data = response.json()
         logger.info(f"External process created: {data}")
-        return data.get('data', None)
+        return data.get("data", None)
 
     def close_process(self) -> DecisionResult:
-        model = ExternalProcess.objects.filter(
-            policy=self.policy, action=self.action).first()
-        if not model or not model.location:
-            raise Exception(
-                "Unable to close process, location or model missing")
+        try:
+            model = ExternalProcess.objects.get(policy=self.policy, action=self.action)
+        except ExternalProcess.DoesNotExist:
+            raise Exception("ExternalProcess not found")
+        if not model.location:
+            raise Exception("ExternalProcess missing location")
         logger.info(f"Making request to close process at '{model.location}'")
         resource_url = f"{settings.METAGOV_URL}{model.location}"
         response = requests.delete(resource_url)
         if not response.ok:
-            raise Exception(
-                f"Error getting process data: {response.status_code} {response.reason} {response.text}")
+            raise Exception(f"Error getting process data: {response.status_code} {response.reason} {response.text}")
         data = response.json()
         logger.info(f"External process closed: {data}")
-        assert(data.get('status') == 'completed')
+        assert data.get("status") == "completed"
         return DecisionResult(data)
 
     def get_process_outcome(self) -> DecisionResult:
-        model = ExternalProcess.objects.filter(
-            policy=self.policy, action=self.action).first()
+        model = ExternalProcess.objects.filter(policy=self.policy, action=self.action).first()
         if model and model.json_data:
             data = json.loads(model.json_data)
             # json_data is only present when external process is completed
-            assert(data.get('status') == 'completed')
+            assert data.get("status") == "completed"
             return DecisionResult(data)
         return None
 
@@ -115,7 +102,18 @@ class Metagov:
         url = f"{settings.METAGOV_URL}/api/internal/resource/{resource_name}"
         response = requests.get(url, params=payload, headers=self.headers)
         if not response.ok:
-            raise Exception(
-                f"Error getting resource: {response.status_code} {response.text}")
+            raise Exception(f"Error getting resource: {response.status_code} {response.reason} {response.text}")
+        data = response.json()
+        return data
+
+    def perform_action(self, action_type, parameters):
+        """
+        Perform an action through Metagov. If the requested action belongs to a plugin that is
+        not active for the current community, this will throw an exception.
+        """
+        url = f"{settings.METAGOV_URL}/api/internal/action/{action_type}"
+        response = requests.post(url, json={"parameters": parameters}, headers=self.headers)
+        if not response.ok:
+            raise Exception(f"Error performing action: {response.status_code} {response.reason} {response.text}")
         data = response.json()
         return data

--- a/policykit/integrations/metagov/urls.py
+++ b/policykit/integrations/metagov/urls.py
@@ -4,8 +4,8 @@ from integrations.metagov import views
 
 
 urlpatterns = [
-    path('outcome/<int:id>', views.post_outcome),
-    path('config', views.config_editor),
-    path('save_config', views.save_config),
-    path('action', views.action),
+    path("outcome/<int:id>", views.post_outcome),
+    path("config", views.config_editor),
+    path("save_config", views.save_config),
+    path("action", views.action),
 ]

--- a/policykit/policyengine/filter.py
+++ b/policykit/policyengine/filter.py
@@ -45,6 +45,7 @@ whitelisted_modules = {
         "close_process",
         "get_process_outcome",
         "get_resource",
+        "perform_action",
     ],
     "base64": [
         "a85encode",


### PR DESCRIPTION
Expose a way for policy authors to perform [metagov actions](https://prototype.metagov.org/redoc/#tag/Actions). This is what it looks like in a policy:
```
response = metagov.perform_action('randomness.random-int', {"low": 0, "high": 100})
```