### PR TITLE
Only enable metagov if METAGOV_URL is defined

### DIFF
--- a/policykit/policykit/settings.py
+++ b/policykit/policykit/settings.py
@@ -37,10 +37,10 @@ ALLOWED_HOSTS = ['policykit.org',
                  'ec2-54-190-197-117.us-west-2.compute.amazonaws.com',
                  '54.190.197.117']
 
-METAGOV_ENABLED = True
 try:
-    METAGOV_URL
+    METAGOV_ENABLED = True if METAGOV_URL else False
 except NameError:
+    # "METAGOV_URL" is missing from private.py
     METAGOV_ENABLED = False
 
 # Application definition


### PR DESCRIPTION
The commit https://github.com/amyxzhang/policykit/commit/1f420fb6288b3fe0d90281e1d68186f46cfa21b0 introduced a bug where Metagov would be considered "enabled" if the `private.py` file looked like this:

https://github.com/amyxzhang/policykit/blob/a023c7be64e84ad6f95439dba1d7d57c3ef543ef/policykit/private_template.py#L2


Metagov should only be enabled if there is a URL for it.