### PR TITLE
Set is_community_admin for Discourse users; use it to set new can_edit_metagov_config perm

### DIFF
--- a/policykit/integrations/discourse/models.py
+++ b/policykit/integrations/discourse/models.py
@@ -49,16 +49,17 @@ class DiscourseCommunity(Community):
         req = urllib.request.Request(self.team_id + url, data, method=method)
         req.add_header('User-Api-Key', self.api_key)
 
-        res = None
         try:
             resp = urllib.request.urlopen(req)
-            res = json.loads(resp.read().decode('utf-8'))
         except urllib.error.HTTPError as e:
             logger.info('reached HTTPError')
             logger.info(e.code)
             raise
 
-        return res
+        resp_body = resp.read().decode('utf-8')
+        if resp_body:
+            return json.loads(resp_body)
+        return None
 
     def execute_platform_action(self, action, delete_policykit_post=True):
         from policyengine.models import LogAPICall, CommunityUser
@@ -146,13 +147,14 @@ class DiscourseCreateTopic(PlatformAction):
     def revert(self):
         logger.info('discourse topic revert')
         values = {}
-        super().revert(values, '/t/%s.json' % self.id, method='DELETE')
+        call = f"/t/{self.id}.json"
+        super().revert(values, call, method='DELETE')
 
     def execute(self):
-        if not self.community_revert:
-            topic = self.community.make_call('/posts.json', {'title': self.title, 'raw': self.raw, 'category': self.category})
-
-            self.id = topic['id']
+        # FIXME(#335)
+        # if not self.community_revert:
+        #     topic = self.community.make_call('/posts.json', {'title': self.title, 'raw': self.raw, 'category': self.category})
+        #     self.id = topic['id']
         super().pass_action()
 
 class DiscourseCreatePost(PlatformAction):
@@ -174,13 +176,14 @@ class DiscourseCreatePost(PlatformAction):
 
     def revert(self):
         values = {}
-        super().revert(values, '/posts/%s.json' % self.id, method='DELETE')
+        call = f"/posts/{self.id}.json"
+        super().revert(values, call, method='DELETE')
 
     def execute(self):
-        if not self.community_revert:
-            reply = self.community.make_call('/posts.json', {'raw': self.raw})
-
-            self.id = reply['id']
+        # FIXME(#335)
+        # if not self.community_revert:
+        #     reply = self.community.make_call('/posts.json', {'raw': self.raw})
+        #     self.id = reply['id']
         super().pass_action()
 
 class DiscourseStarterKit(StarterKit):

--- a/policykit/integrations/discourse/tasks.py
+++ b/policykit/integrations/discourse/tasks.py
@@ -42,11 +42,11 @@ def discourse_listener_actions():
         req = urllib.request.Request(url + '/latest.json')
         req.add_header("User-Api-Key", api_key)
         resp = urllib.request.urlopen(req)
-        logger.info(f"{resp.status} {resp.reason}")
+        logger.info(f"[celery-discourse] {resp.status} {resp.reason}")
         res = json.loads(resp.read().decode('utf-8'))
         topics = res['topic_list']['topics']
         users = res['users']
-
+        logger.info(f"[celery-discourse] {len(topics)} topics")
         for topic in topics:
             user_id = topic['posters'][0]['user_id']
             usernames = [u['username'] for u in users if u['id'] == user_id]
@@ -71,6 +71,9 @@ def discourse_listener_actions():
                     )
                     new_api_action.initiator = u
                     actions.append(new_api_action)
+            else:
+                logger.info("[celery-discourse] skipping PK action")
+        logger.info(f"[celery-discourse] {len(actions)} actions created")
         for action in actions:
             action.community_origin = True
             action.is_bundled = False

--- a/policykit/integrations/discourse/utils.py
+++ b/policykit/integrations/discourse/utils.py
@@ -1,0 +1,9 @@
+def get_discourse_user_fields(user_info, community):
+    is_bot = user_info['id'] < 0
+    avatar_small = user_info['avatar_template'].replace("{size}", "45")
+    return {
+        'username': user_info['username'],
+        'readable_name': user_info['name'] or user_info['username'],
+        'is_community_admin': user_info['admin'] and not is_bot,
+        'avatar': community.team_id + avatar_small
+    }

--- a/policykit/integrations/discourse/views.py
+++ b/policykit/integrations/discourse/views.py
@@ -2,6 +2,7 @@ from django.shortcuts import render, redirect
 from django.http import HttpResponse
 from policykit.settings import SERVER_URL
 from integrations.discourse.models import DiscourseCommunity, DiscourseUser, DiscourseStarterKit
+from integrations.discourse.utils import get_discourse_user_fields
 from policyengine.models import *
 from django.contrib.auth import login, authenticate
 from django.views.decorators.csrf import csrf_exempt
@@ -125,12 +126,11 @@ def auth(request):
             users = json.loads(resp.read().decode('utf-8'))
 
             for u in users:
-                du, _ = DiscourseUser.objects.get_or_create(
-                    username=u['username'],
-                    readable_name=u['username'],
-                    community=community
+                user_fields = get_discourse_user_fields(u, community)
+                DiscourseUser.objects.update_or_create(
+                    community=community, username=u['username'],
+                    defaults=user_fields,
                 )
-                du.save()
 
             context = {
                 "starterkits": [kit.name for kit in DiscourseStarterKit.objects.all()],

--- a/policykit/integrations/discourse/views.py
+++ b/policykit/integrations/discourse/views.py
@@ -160,6 +160,7 @@ def post_policy(policy, action, users=None, template=None, topic_id=None):
         'raw': policy_message,
         'topic_id': topic_id
     }
+    # TODO: append a Discourse poll to `raw` to facilitate voting.
 
     call = '/posts.json'
 

--- a/policykit/integrations/metagov/models.py
+++ b/policykit/integrations/metagov/models.py
@@ -36,6 +36,22 @@ class MetagovUser(CommunityUser):
         return self.username
 
 
+class MetagovConfig(models.Model):
+    """
+    Dummy model for permissions to edit Metagov Config.
+    """
+    class Meta:
+        # No database table creation or deletion  \
+        # operations will be performed for this model.
+        managed = False
+
+        # disable "add", "change", "delete"
+        # and "view" default permissions
+        default_permissions = ()
+
+        permissions = [("can_edit_metagov_config", "Can edit Metagov config")]
+
+
 class MetagovPlatformAction(PlatformAction):
     """
     This is a PlatformAction model to use as a policy trigger for events received from Metagov.

--- a/policykit/policyengine/views.py
+++ b/policykit/policyengine/views.py
@@ -130,7 +130,7 @@ def settings_page(request):
     user = get_user(request)
     community = user.community
 
-    if METAGOV_ENABLED and user.is_community_admin:
+    if user.has_perm("metagov.can_edit_metagov_config"):
         metagov_config = get_or_create_metagov_community(community)
         if metagov_config:
             metagov_config = json.dumps(metagov_config, indent=4, separators=(",", ": "))


### PR DESCRIPTION
Fixes some bugs in DiscourseUser creation:
* Set `is_community_admin` if user is admin. This gets set when creating all users on community install, and gets updated when user logs in.
* Set `avatar` to correct link