### PR TITLE
Create Metagov community if it doesn't exist

### DIFF
--- a/policykit/integrations/metagov/library.py
+++ b/policykit/integrations/metagov/library.py
@@ -27,12 +27,13 @@ def update_metagov_community(community: Community, plugins=[]):
     data = response.json()
     return data
 
-def get_metagov_community(community: Community):
+def get_or_create_metagov_community(community: Community):
     url = f"{settings.METAGOV_URL}/api/internal/community/{metagov_slug(community)}"
     response = requests.get(url)
-    if not response.ok:
-        logger.error(response.text)
-        return None
+    if response.status_code == 404:
+        return update_metagov_community(community)
+    elif not response.ok:
+        raise Exception(response.text or "Unknown error")
     return response.json()
 
 class DecisionResult(object):

--- a/policykit/integrations/metagov/models.py
+++ b/policykit/integrations/metagov/models.py
@@ -23,7 +23,7 @@ class ExternalProcess(models.Model):
 class MetagovUser(CommunityUser):
     provider = models.CharField(max_length=30, help_text="Identity provider that the username comes from")
     """
-    Represents a user in the MetagovCommunity, which could be on any platform.
+    Represents a user in the Metagov community, which could be on any platform.
     """
 
     # Hack so it doesn't clash with usernames from other communities (django User requires unique username).

--- a/policykit/policyengine/views.py
+++ b/policykit/policyengine/views.py
@@ -125,13 +125,13 @@ def logout(request):
 
 @login_required(login_url='/login')
 def settings_page(request):
-    from integrations.metagov.library import get_metagov_community
+    from integrations.metagov.library import get_or_create_metagov_community
 
     user = get_user(request)
     community = user.community
 
     if METAGOV_ENABLED and user.is_community_admin:
-        metagov_config = get_metagov_community(community)
+        metagov_config = get_or_create_metagov_community(community)
         if metagov_config:
             metagov_config = json.dumps(metagov_config, indent=4, separators=(",", ": "))
     else:


### PR DESCRIPTION
If the Community was created before Metagov was enabled, then the Metagov Community needs to be created at some point. Here we create it when first navigating to the settings page.