### PR TITLE
Post loading

### DIFF
--- a/policykit/integrations/discourse/models.py
+++ b/policykit/integrations/discourse/models.py
@@ -28,7 +28,6 @@ class DiscourseCommunity(Community):
     api_key = models.CharField('api_key', max_length=100, unique=True)
 
     def notify_action(self, action, policy, users=None, template=None, topic_id=None):
-        logger.info('in notify_action')
         from integrations.discourse.views import post_policy
         post_policy(policy, action, users, template, topic_id)
 

--- a/policykit/integrations/discourse/tasks.py
+++ b/policykit/integrations/discourse/tasks.py
@@ -15,21 +15,22 @@ import json
 
 logger = logging.getLogger(__name__)
 
-def is_policykit_action(community, call_type, topic, username):
-    if username == 'PolicyKit': ## TODO: Compare IDs in future, not usernames
-        return True
+def should_create_action(community, call_type, topic, username):
+    # If topic already has an object, don't create a new object for it.
+    if DiscourseCreateTopic.objects.filter(id=topic['id']).exists():
+        return False
 
-    current_time_minus = datetime.datetime.now() - datetime.timedelta(minutes=2)
-    logs = LogAPICall.objects.filter(
-        proposal_time__gte=current_time_minus,
-        call_type=call_type
-    )
-    if logs.exists():
-        for log in logs:
-            j_info = json.loads(log.extra_info)
-            if topic['id'] == j_info['id']:
-                return True
-    return False
+    created_at = topic['created_at']
+    created_at = created_at.replace("Z", "+00:00")
+    created_at = datetime.datetime.fromisoformat(created_at)
+
+    # If topic is more than two minutes old, don't create an object for it.
+    # This way, we only create objects for topics created after PolicyKit
+    # has been installed to the community.
+    if datetime.datetime.now() - created_at > datetime.timedelta(minutes=2):
+        return False
+
+    return True
 
 @shared_task
 def discourse_listener_actions():
@@ -55,34 +56,30 @@ def discourse_listener_actions():
                 continue
             username = usernames[0]
             call_type = '/posts.json'
-            if not is_policykit_action(community, call_type, topic, username):
-                t = DiscourseCreateTopic.objects.filter(id=topic['id'])
-                if not t.exists():
-                    logger.info(f"[celery-discourse] creating new DiscourseCreateTopic object for topic {topic['title']}")
+            if should_create_action(community, call_type, topic, username):
+                logger.info(f"[celery-discourse] creating new DiscourseCreateTopic object for topic {topic['title']}")
 
-                    # Retrieve raw from first post under topic (created when topic created)
-                    req = urllib.request.Request(f"{url}/t/{str(topic['id'])}/posts.json?include_raw=True")
-                    req.add_header("User-Api-Key", api_key)
-                    resp = urllib.request.urlopen(req)
-                    logger.info(f"[celery-discourse] raw post response: {resp.status} {resp.reason}")
-                    res = json.loads(resp.read().decode('utf-8'))
-                    raw = res['post_stream']['posts'][0]['raw']
+                # Retrieve raw from first post under topic (created when topic created)
+                req = urllib.request.Request(f"{url}/t/{str(topic['id'])}/posts.json?include_raw=True")
+                req.add_header("User-Api-Key", api_key)
+                resp = urllib.request.urlopen(req)
+                logger.info(f"[celery-discourse] raw post response: {resp.status} {resp.reason}")
+                res = json.loads(resp.read().decode('utf-8'))
+                raw = res['post_stream']['posts'][0]['raw']
 
-                    new_api_action = DiscourseCreateTopic()
-                    new_api_action.community = community
-                    new_api_action.title = topic['title']
-                    new_api_action.category = topic['category_id']
-                    new_api_action.raw = raw
-                    new_api_action.id = topic['id']
+                new_api_action = DiscourseCreateTopic()
+                new_api_action.community = community
+                new_api_action.title = topic['title']
+                new_api_action.category = topic['category_id']
+                new_api_action.raw = raw
+                new_api_action.id = topic['id']
 
-                    u,_ = DiscourseUser.objects.get_or_create(
-                        username=username,
-                        community=community
-                    )
-                    new_api_action.initiator = u
-                    actions.append(new_api_action)
-            else:
-                logger.info("[celery-discourse] skipping PK action")
+                u,_ = DiscourseUser.objects.get_or_create(
+                    username=username,
+                    community=community
+                )
+                new_api_action.initiator = u
+                actions.append(new_api_action)
         logger.info(f"[celery-discourse] {len(actions)} actions created")
         for action in actions:
             action.community_origin = True

--- a/policykit/integrations/discourse/tasks.py
+++ b/policykit/integrations/discourse/tasks.py
@@ -24,10 +24,13 @@ def should_create_action(community, call_type, topic, username):
     created_at = created_at.replace("Z", "+00:00")
     created_at = datetime.datetime.fromisoformat(created_at)
 
+    now = datetime.datetime.now()
+    now = now.replace(tzinfo=datetime.timezone.utc) # Makes the datetime object timezone-aware
+
     # If topic is more than two minutes old, don't create an object for it.
     # This way, we only create objects for topics created after PolicyKit
     # has been installed to the community.
-    if datetime.datetime.now() - created_at > datetime.timedelta(minutes=2):
+    if now - created_at > datetime.timedelta(minutes=2):
         return False
 
     return True

--- a/policykit/policykit/settings.py
+++ b/policykit/policykit/settings.py
@@ -224,18 +224,19 @@ CELERY_BROKER_URL = 'amqp://'
 CELERY_RESULT_BACKEND = 'django-db'
 CELERY_CACHE_BACKEND = 'django-cache'
 
+CELERY_BEAT_FREQUENCY = 60.0
 
 CELERY_BEAT_SCHEDULE = {
  'count-votes-beat': {
        'task': 'policyengine.tasks.consider_proposed_actions',
-       'schedule': 60.0,
+       'schedule': CELERY_BEAT_FREQUENCY,
     },
  'reddit-listener-beat': {
        'task': 'integrations.reddit.tasks.reddit_listener_actions',
-       'schedule': 60.0,
+       'schedule': CELERY_BEAT_FREQUENCY,
     },
  'discourse-listener-beat': {
        'task': 'integrations.discourse.tasks.discourse_listener_actions',
-       'schedule': 60.0,
+       'schedule': CELERY_BEAT_FREQUENCY,
     }
 }


### PR DESCRIPTION
Fixes #319 

There are two possible ways to fix the rate-limiting problem / Discourse integration loading on startup all previous posts that occurred prior to its integration into the community.
 1. Compare the post creation time to the PK community creation time. Only create an object in the db for the post if post creation time is after PK community creation time.
 2. Compare the post creation time to the current time. Only create an object in the db if the post occurred recently enough to the current time (within the last two minutes).

Ultimately I decided on approach 2 to avoid cases where PK may be added/removed to the community multiple times (we don't want to retroactively govern posts that occurred during periods where PK was removed). Let me know if you would prefer approach 1 though!