### PR TITLE
Only execute one policy per action, choose the most recently modified policy

### DIFF
--- a/policykit/integrations/discourse/models.py
+++ b/policykit/integrations/discourse/models.py
@@ -52,8 +52,10 @@ class DiscourseCommunity(Community):
         try:
             resp = urllib.request.urlopen(req)
         except urllib.error.HTTPError as e:
-            logger.info('reached HTTPError')
-            logger.info(e.code)
+            logger.error('reached HTTPError')
+            logger.error(e.code)
+            error_message = e.read()
+            logger.error(error_message)
             raise
 
         resp_body = resp.read().decode('utf-8')

--- a/policykit/integrations/discourse/models.py
+++ b/policykit/integrations/discourse/models.py
@@ -182,7 +182,7 @@ class DiscourseCreatePost(PlatformAction):
     def execute(self):
         # only execute the action if it didnt originate in the community, OR if it was previously reverted
         if not self.community_origin or (self.community_origin and self.community_revert):
-            reply = self.community.make_call('/posts.json', {'raw': self.raw})
+            reply = self.community.make_call('/posts.json', {'raw': self.raw}) #FIXME this needs to have topic_id
             self.post_id = reply['id']
             self.save()
         super().pass_action()

--- a/policykit/integrations/discourse/models.py
+++ b/policykit/integrations/discourse/models.py
@@ -150,7 +150,8 @@ class DiscourseCreateTopic(PlatformAction):
         super().revert(values, call, method='DELETE')
 
     def execute(self):
-        if not self.community_revert:
+        # only execute the action if it didnt originate in the community, OR if it was previously reverted
+        if not self.community_origin or (self.community_origin and self.community_revert):
             topic = self.community.make_call('/posts.json', {'title': self.title, 'raw': self.raw, 'category': self.category})
 
             self.topic_id = topic['id']
@@ -179,7 +180,8 @@ class DiscourseCreatePost(PlatformAction):
         super().revert(values, call, method='DELETE')
 
     def execute(self):
-        if not self.community_revert:
+        # only execute the action if it didnt originate in the community, OR if it was previously reverted
+        if not self.community_origin or (self.community_origin and self.community_revert):
             reply = self.community.make_call('/posts.json', {'raw': self.raw})
             self.post_id = reply['id']
             self.save()

--- a/policykit/policyengine/models.py
+++ b/policykit/policyengine/models.py
@@ -377,7 +377,10 @@ class ConstitutionAction(BaseAction, PolymorphicModel):
                         action.execute()
                     else:
                         for policy in self.community.get_constitution_policies():
-                            execute_policy(policy, action, is_first_evaluation=True)
+                            # Execute the most recently updated policy that passes filter()
+                            was_executed = execute_policy(policy, action, is_first_evaluation=True)
+                            if was_executed:
+                                break
             else:
                 self.proposal = Proposal.objects.create(status=Proposal.FAILED, author=self.initiator)
         else:
@@ -428,7 +431,10 @@ class ConstitutionActionBundle(BaseAction):
                     action.execute()
                 else:
                     for policy in self.community.get_constitution_policies():
-                        execute_policy(policy, action, is_first_evaluation=True)
+                        # Execute the most recently updated policy that passes filter()
+                        was_executed = execute_policy(policy, action, is_first_evaluation=True)
+                        if was_executed:
+                            break
 
         super(ConstitutionActionBundle, self).save(*args, **kwargs)
 
@@ -854,7 +860,10 @@ class PlatformAction(BaseAction,PolymorphicModel):
                         action.execute()
                     else:
                         for policy in self.community.get_platform_policies():
-                            execute_policy(policy, action, is_first_evaluation=True)
+                            # Execute the most recently updated policy that passes filter()
+                            was_executed = execute_policy(policy, action, is_first_evaluation=True)
+                            if was_executed:
+                                break
             else:
                 self.proposal = Proposal.objects.create(status=Proposal.FAILED,
                                                         author=self.initiator)
@@ -903,7 +912,10 @@ class PlatformActionBundle(BaseAction):
                     action.execute()
                 elif not action.community_post:
                     for policy in action.community.get_platform_policies():
-                        execute_policy(policy, action, is_first_evaluation=True)
+                        # Execute the most recently updated policy that passes filter()
+                        was_executed = execute_policy(policy, action, is_first_evaluation=True)
+                        if was_executed:
+                            break
 
         super(PlatformActionBundle, self).save(*args, **kwargs)
 

--- a/policykit/policyengine/tasks.py
+++ b/policykit/policyengine/tasks.py
@@ -17,7 +17,10 @@ def consider_proposed_actions():
             action.execute()
         else:
             for policy in action.community.get_platform_policies():
-                execute_policy(policy, action, is_first_evaluation=False)
+                # Execute the most recently updated policy that passes filter()
+                was_executed = execute_policy(policy, action, is_first_evaluation=False)
+                if was_executed:
+                    break
 
     """bundle_actions = PlatformActionBundle.objects.filter(proposal__status=Proposal.PROPOSED)
     for action in bundle_actions:
@@ -36,7 +39,10 @@ def consider_proposed_actions():
         if action.initiator.has_perm(action.app_name + '.can_execute_' + action.action_codename):
             action.execute()
         else:
-            for policy in action.community.get_constitution_policies()::
-                execute_policy(policy, action, is_first_evaluation=False)
+            for policy in action.community.get_constitution_policies():
+                # Execute the most recently updated policy that passes filter()
+                was_executed = execute_policy(policy, action, is_first_evaluation=False)
+                if was_executed:
+                    break
 
     logger.info('[celery] finished task')

--- a/policykit/policyengine/tasks.py
+++ b/policykit/policyengine/tasks.py
@@ -16,7 +16,7 @@ def consider_proposed_actions():
         if action.initiator.has_perm(action.app_name + '.can_execute_' + action.action_codename):
             action.execute()
         else:
-            for policy in PlatformPolicy.objects.filter(community=action.community):
+            for policy in action.community.get_platform_policies():
                 execute_policy(policy, action, is_first_evaluation=False)
 
     """bundle_actions = PlatformActionBundle.objects.filter(proposal__status=Proposal.PROPOSED)
@@ -26,7 +26,7 @@ def consider_proposed_actions():
         if action.initiator.has_perm(action.app_name + '.can_execute_' + action.action_codename):
             action.execute()
         else:
-            for policy in PlatformPolicy.objects.filter(community=action.community):
+            for policy in action.community.get_platform_policies():
                 execute_policy(policy, action)"""
 
     constitution_actions = ConstitutionAction.objects.filter(proposal__status=Proposal.PROPOSED, is_bundled=False)
@@ -36,7 +36,7 @@ def consider_proposed_actions():
         if action.initiator.has_perm(action.app_name + '.can_execute_' + action.action_codename):
             action.execute()
         else:
-            for policy in ConstitutionPolicy.objects.filter(community=action.community):
+            for policy in action.community.get_constitution_policies()::
                 execute_policy(policy, action, is_first_evaluation=False)
 
     logger.info('[celery] finished task')

--- a/policykit/policyengine/views.py
+++ b/policykit/policyengine/views.py
@@ -675,6 +675,7 @@ def document_action_remove(request):
 def execute_policy(policy, action, is_first_evaluation: bool):
     """
     Execute policy for given action. This can be run repeatedly to check proposed actions.
+    Return 'True' if action passed the filter, 'False' otherwise.
     """
     if filter_policy(policy, action):
         from policyengine.models import Proposal
@@ -722,3 +723,7 @@ def execute_policy(policy, action, is_first_evaluation: bool):
         else:
             # do nothing, it's still pending
             pass
+
+        return True
+    else:
+        return False

--- a/policykit/policyengine/views.py
+++ b/policykit/policyengine/views.py
@@ -35,10 +35,10 @@ def v2(request):
     user = get_user(request)
 
     users = CommunityUser.objects.filter(community=user.community)
-    roles = CommunityRole.objects.filter(community=user.community)
-    docs = CommunityDoc.objects.filter(community=user.community)
-    platform_policies = PlatformPolicy.objects.filter(community=user.community)
-    constitution_policies = ConstitutionPolicy.objects.filter(community=user.community)
+    roles = user.community.get_roles()
+    docs = user.community.get_documents()
+    platform_policies = user.community.get_platform_policies()
+    constitution_policies = user.community.get_constitution_policies()
 
     # Indexing entries by username/name allows retrieval in O(1) rather than O(n)
     user_data = {}
@@ -256,9 +256,9 @@ def selectpolicy(request):
     operation = request.GET.get('operation')
 
     if type == 'Platform':
-        policies = PlatformPolicy.objects.filter(community=user.community)
+        policies = user.community.get_platform_policies()
     elif type == 'Constitution':
-        policies = ConstitutionPolicy.objects.filter(community=user.community)
+        policies = user.community.get_constitution_policies()
     else:
         return HttpResponseBadRequest()
 


### PR DESCRIPTION
I'll describe this change through an example. Assume that action X passes the `filter` block for policies A and B, and fails the `filter` block for policy C. Policy A was created before policy B.

**Old behavior:**

When action X occurs, both policies A and B get fully executed (the full sequence of check/notify/pass/fail occurs for both policies). Policy A gets evaluated first, then policy B gets evaluated. Policy A decides that the action failed, it runs the policy's `fail` code and sets the proposal status to `failed`. Then policy B decides that the action passed, and runs policy B's `pass` code and sets the proposal status to `passed. And so on. The interactions between the policies is unclear to the author.

**New behavior:**

When action X occurs, only policy B gets fully executed (the full sequence of check/notify/pass/fail). Policy A is ignored, because it is older.

**Bugs:**

There is still some unpredictable behavior for actions that are in "proposed" state waiting for a vote to occur (or other async process). If policies are modified during the wait-time, the action might suddenly pass/fail due to some _other_ policy (NOT the one that initiated the voting process). This is not a _new_ bug, but it is a bug that will continue to exist. I think the desired behavior is that when an action moves into `proposed` state and starts getting polled every minute, it should always be polled against the same Policy that originally caused it to go into `proposed` state. This requires a link between the `action` and the `policy`, which doesn't currently exist.

