### PR TITLE
Fix discourse 422 bug

### DIFF
--- a/policykit/integrations/discourse/models.py
+++ b/policykit/integrations/discourse/models.py
@@ -163,6 +163,7 @@ class DiscourseCreateTopic(PlatformAction):
             # will flag re-created topic as repetitive post and fail it with
             # a 422 error: "Title has already been used".
             self.community.make_call(f"/t/{self.topic_id}/recover", method='PUT')
+            self.community_revert = False
 
         super().pass_action()
 

--- a/policykit/integrations/discourse/models.py
+++ b/policykit/integrations/discourse/models.py
@@ -145,18 +145,25 @@ class DiscourseCreateTopic(PlatformAction):
         )
 
     def revert(self):
-        logger.info('discourse topic revert')
         values = {}
         call = f"/t/{self.topic_id}.json"
         super().revert(values, call, method='DELETE')
 
     def execute(self):
-        # only execute the action if it didnt originate in the community, OR if it was previously reverted
-        if not self.community_origin or (self.community_origin and self.community_revert):
+        # Execute action if it didnt originate in the community
+        if not self.community_origin:
             topic = self.community.make_call('/posts.json', {'title': self.title, 'raw': self.raw, 'category': self.category})
 
             self.topic_id = topic['id']
             self.save()
+
+        # Execute action if it was previously reverted
+        if self.community_origin and self.community_revert:
+            # Recover topic rather than re-creating because otherwise Discourse
+            # will flag re-created topic as repetitive post and fail it with
+            # a 422 error: "Title has already been used".
+            self.community.make_call(f"/t/{self.topic_id}/recover", method='PUT')
+
         super().pass_action()
 
 class DiscourseCreatePost(PlatformAction):

--- a/policykit/policyengine/views.py
+++ b/policykit/policyengine/views.py
@@ -696,6 +696,7 @@ def execute_policy(policy, action, is_first_evaluation: bool):
         if check_result == Proposal.PASSED:
             # run "pass" block of policy
             pass_policy(policy, action)
+            logger.info(f"{log_prefix} Executed pass block of policy")
             # mark action proposal as 'passed'
             action.pass_action()
             assert(action.proposal.status == Proposal.PASSED)
@@ -703,6 +704,7 @@ def execute_policy(policy, action, is_first_evaluation: bool):
         elif check_result == Proposal.FAILED:
             # run "fail" block of policy
             fail_policy(policy, action)
+            logger.info(f"{log_prefix} Executed fail block of policy")
             # mark action proposal as 'failed'
             action.fail_action()
             assert(action.proposal.status == Proposal.FAILED)

--- a/policykit/scripts/starterkits.py
+++ b/policykit/scripts/starterkits.py
@@ -8,7 +8,7 @@ from integrations.slack.models import SlackStarterKit
 from policyengine.models import *
 from polymorphic.models import PolymorphicModel
 
-# default starterkit -- all users have ability to view/propose actions + all actions pass automatically
+# default starterkit -- all users have ability to view/propose actions + all constitution actions execute automatically
 testing_starterkit_slack = SlackStarterKit(name="Testing Starter Kit", platform="slack")
 testing_starterkit_slack.save()
 
@@ -30,9 +30,18 @@ all_actions_pass = {
     "fail": "pass",
 }
 
+all_actions_execute = {
+    "filter": "return True",
+    "initialize": "pass",
+    "check": "return PASSED",
+    "notify": "pass",
+    "success": "action.execute()",
+    "fail": "pass",
+}
+
 testing_policy1_slack = GenericPolicy.objects.create(
-    **all_actions_pass,
-    description="Starter Constitution Policy: all constitution actions pass automatically",
+    **all_actions_execute,
+    description="Starter Constitution Policy: all constitution actions execute automatically",
     name="All Constitution Actions Pass",
     starterkit=testing_starterkit_slack,
     is_constitution=True,
@@ -49,8 +58,8 @@ testing_policy2_slack = GenericPolicy.objects.create(
 )
 
 testing_policy1_reddit = GenericPolicy.objects.create(
-    **all_actions_pass,
-    description="Starter Constitution Policy: all constitution actions pass automatically",
+    **all_actions_execute,
+    description="Starter Constitution Policy: all constitution actions execute automatically",
     name="All Constitution Actions Pass",
     starterkit=testing_starterkit_reddit,
     is_constitution=True,
@@ -67,8 +76,8 @@ testing_policy2_reddit = GenericPolicy.objects.create(
 )
 
 testing_policy1_discord = GenericPolicy.objects.create(
-    **all_actions_pass,
-    description="Starter Constitution Policy: all constitution actions pass automatically",
+    **all_actions_execute,
+    description="Starter Constitution Policy: all constitution actions execute automatically",
     name="All Constitution Actions Pass",
     starterkit=testing_starterkit_discord,
     is_constitution=True,
@@ -76,12 +85,7 @@ testing_policy1_discord = GenericPolicy.objects.create(
 )
 
 testing_policy2_discord = GenericPolicy.objects.create(
-    filter="return True",
-    initialize="pass",
-    check="return PASSED",
-    notify="pass",
-    success="action.execute()",
-    fail="pass",
+    **all_actions_pass,
     description="Starter Platform Policy: all platform actions pass automatically",
     name="All Platform Actions Pass",
     starterkit=testing_starterkit_discord,
@@ -90,8 +94,8 @@ testing_policy2_discord = GenericPolicy.objects.create(
 )
 
 testing_policy1_discourse = GenericPolicy.objects.create(
-    **all_actions_pass,
-    description="Starter Constitution Policy: all constitution actions pass automatically",
+    **all_actions_execute,
+    description="Starter Constitution Policy: all constitution actions execute automatically",
     name="All Constitution Actions Pass",
     starterkit=testing_starterkit_discourse,
     is_constitution=True,


### PR DESCRIPTION
Fixes the 422 error which Discourse throws when attempting to recover a topic that has already been deleted. Error is thrown because re-making the post rather than recovering it triggers Discourse's "Topic name has already been used" filter.