### PR TITLE
Make Discord Integration fully-functional

### DIFF
--- a/policykit/integrations/discord/apps.py
+++ b/policykit/integrations/discord/apps.py
@@ -1,6 +1,5 @@
 from django.apps import AppConfig
 
-
 class discordIntegrationConfig(AppConfig):
     name = 'integrations.discord'
 

--- a/policykit/integrations/discord/auth_backends.py
+++ b/policykit/integrations/discord/auth_backends.py
@@ -25,7 +25,7 @@ class DiscordBackend(BaseBackend):
         resp = urllib.request.urlopen(req)
         user_info = json.loads(resp.read().decode('utf-8'))
 
-        discord_user = DiscordUser.objects.filter(username=user_info['id'])
+        discord_user = DiscordUser.objects.filter(username=f"{user_info['id']}:{guild_id}")
 
         if discord_user.exists():
             # update user info
@@ -37,7 +37,7 @@ class DiscordBackend(BaseBackend):
             discord_user.save()
         else:
             discord_user,_ = DiscordUser.objects.get_or_create(
-                username = user_info['id'],
+                username = f"{user_info['id']}:{guild_id}",
                 password = access_token,
                 community = community,
                 readable_name = user_info['username'],

--- a/policykit/integrations/discord/auth_backends.py
+++ b/policykit/integrations/discord/auth_backends.py
@@ -10,7 +10,10 @@ logger = logging.getLogger(__name__)
 
 class DiscordBackend(BaseBackend):
 
-    def authenticate(self, guild_id, access_token):
+    def authenticate(self, request, guild_id=None, access_token=None):
+        if not guild_id or not access_token:
+            return None
+
         community = DiscordCommunity.objects.filter(team_id=guild_id)
         if not community.exists():
             return None

--- a/policykit/integrations/discord/auth_backends.py
+++ b/policykit/integrations/discord/auth_backends.py
@@ -10,11 +10,12 @@ logger = logging.getLogger(__name__)
 
 class DiscordBackend(BaseBackend):
 
-    def authenticate(self, request, oauth=None, platform=None):
-        if not oauth or platform != "discord":
+    def authenticate(self, request, oauth=None):
+        if not oauth:
             return None
 
         guild_id = request.GET.get('guild_id')
+        logger.info(guild_id)
 
         community = DiscordCommunity.objects.filter(team_id=guild_id)
         if not community.exists():

--- a/policykit/integrations/discord/auth_backends.py
+++ b/policykit/integrations/discord/auth_backends.py
@@ -14,45 +14,38 @@ class DiscordBackend(BaseBackend):
         if not oauth or platform != "discord":
             return None
 
-        req = urllib.request.Request('https://www.discordapp.com/api/users/@me/guilds')
+        guild_id = request.GET.get('guild_id')
+
+        community = DiscordCommunity.objects.filter(team_id=guild_id)
+        if not community.exists():
+            return None
+        community = community[0]
+
+        req = urllib.request.Request('https://www.discordapp.com/api/users/@me')
         req.add_header('Authorization', 'Bearer %s' % oauth['access_token'])
         req.add_header("User-Agent", "Mozilla/5.0") # yes, this is strange. discord requires it when using urllib for some weird reason
         resp = urllib.request.urlopen(req)
-        user_guilds = json.loads(resp.read().decode('utf-8'))
+        user_info = json.loads(resp.read().decode('utf-8'))
 
-        community = None
-        for guild in user_guilds:
-            s = DiscordCommunity.objects.filter(team_id=guild['id'])
-            if s.exists():
-                community = s[0]
+        discord_user = DiscordUser.objects.filter(username=user_info['id'])
 
-        if community:
-            req = urllib.request.Request('https://www.discordapp.com/api/users/@me')
-            req.add_header('Authorization', 'Bearer %s' % oauth['access_token'])
-            req.add_header("User-Agent", "Mozilla/5.0") # yes, this is strange. discord requires it when using urllib for some weird reason
-            resp = urllib.request.urlopen(req)
-            user_info = json.loads(resp.read().decode('utf-8'))
-
-            discord_user = DiscordUser.objects.filter(username=user_info['id'])
-
-            if discord_user.exists():
-                # update user info
-                discord_user = discord_user[0]
-                discord_user.community = community
-                discord_user.password = oauth['access_token']
-                discord_user.readable_name = user_info['username']
-                discord_user.avatar = user_info['avatar']
-                discord_user.save()
-            else:
-                discord_user,_ = DiscordUser.objects.get_or_create(
-                    username = user_info['id'],
-                    password = oauth['access_token'],
-                    community = community,
-                    readable_name = user_info['username'],
-                    avatar = user_info['avatar'],
-                )
-            return discord_user
-        return None
+        if discord_user.exists():
+            # update user info
+            discord_user = discord_user[0]
+            discord_user.password = oauth['access_token']
+            discord_user.community = community
+            discord_user.readable_name = user_info['username']
+            discord_user.avatar = user_info['avatar']
+            discord_user.save()
+        else:
+            discord_user,_ = DiscordUser.objects.get_or_create(
+                username = user_info['id'],
+                password = oauth['access_token'],
+                community = community,
+                readable_name = user_info['username'],
+                avatar = user_info['avatar'],
+            )
+        return discord_user
 
     def get_user(self, user_id):
         try:

--- a/policykit/integrations/discord/auth_backends.py
+++ b/policykit/integrations/discord/auth_backends.py
@@ -11,10 +11,7 @@ logger = logging.getLogger(__name__)
 class DiscordBackend(BaseBackend):
 
     def authenticate(self, request, oauth=None, platform=None):
-        if not oauth:
-            return None
-
-        if platform != 'discord':
+        if not oauth or platform != "discord":
             return None
 
         req = urllib.request.Request('https://www.discordapp.com/api/users/@me/guilds')
@@ -41,7 +38,6 @@ class DiscordBackend(BaseBackend):
             if discord_user.exists():
                 # update user info
                 discord_user = discord_user[0]
-                discord_user.access_token = oauth['access_token']
                 discord_user.community = community
                 discord_user.password = oauth['access_token']
                 discord_user.readable_name = user_info['username']
@@ -54,7 +50,6 @@ class DiscordBackend(BaseBackend):
                     community = community,
                     readable_name = user_info['username'],
                     avatar = user_info['avatar'],
-                    access_token = oauth['access_token'],
                 )
             return discord_user
         return None

--- a/policykit/integrations/discord/models.py
+++ b/policykit/integrations/discord/models.py
@@ -71,7 +71,6 @@ class DiscordUser(CommunityUser):
         group.user_set.add(self)
 
 class DiscordPostMessage(PlatformAction):
-    guild_id = models.IntegerField()
     channel_id = models.IntegerField()
     message_id = models.IntegerField()
     text = models.TextField()
@@ -103,7 +102,6 @@ class DiscordPostMessage(PlatformAction):
         super().pass_action()
 
 class DiscordRenameChannel(PlatformAction):
-    guild_id = models.IntegerField()
     channel_id = models.IntegerField()
     name = models.TextField()
     name_old = models.TextField()

--- a/policykit/integrations/discord/models.py
+++ b/policykit/integrations/discord/models.py
@@ -111,7 +111,7 @@ class DiscordPostMessage(PlatformAction):
 class DiscordRenameChannel(PlatformAction):
     channel_id = models.IntegerField()
     name = models.TextField()
-    name_old = models.TextField(null=True)
+    name_old = models.TextField(blank=True, default='')
 
     ACTION = f"channels/{channel_id}"
     AUTH = 'user'

--- a/policykit/integrations/discord/models.py
+++ b/policykit/integrations/discord/models.py
@@ -111,7 +111,7 @@ class DiscordPostMessage(PlatformAction):
 class DiscordRenameChannel(PlatformAction):
     channel_id = models.IntegerField()
     name = models.TextField()
-    name_old = models.TextField()
+    name_old = models.TextField(null=True)
 
     ACTION = f"channels/{channel_id}"
     AUTH = 'user'

--- a/policykit/integrations/discord/models.py
+++ b/policykit/integrations/discord/models.py
@@ -95,7 +95,7 @@ class DiscordPostMessage(PlatformAction):
         )
 
     def revert(self):
-        super().revert({}, "channels/{self.channel_id}/messages/{self.message_id}", method='DELETE')
+        super().revert({}, f"channels/{self.channel_id}/messages/{self.message_id}", method='DELETE')
 
     def execute(self):
         # Execute action if it didn't originate in the community OR it was previously reverted

--- a/policykit/integrations/discord/models.py
+++ b/policykit/integrations/discord/models.py
@@ -13,48 +13,19 @@ import logging
 logger = logging.getLogger(__name__)
 
 DISCORD_ACTIONS = [
-                    'discordpostmessage',
-                    'discordrenamechannel'
-                  ]
+    'discordpostmessage',
+    'discordrenamechannel'
+]
 
 DISCORD_VIEW_PERMS = ['Can view discord post message', 'Can view discord rename channel']
-
 DISCORD_PROPOSE_PERMS = ['Can add discord post message', 'Can add discord rename channel']
-
 DISCORD_EXECUTE_PERMS = ['Can execute discord post message', 'Can execute discord rename channel']
-
-def refresh_access_token(refresh_token):
-    data = parse.urlencode({
-        'grant_type': 'refresh_token',
-        'refresh_token': refresh_token
-        }).encode()
-
-    req = urllib.request.Request('https://discordapp.com/api/oauth2/token', data=data)
-
-    credentials = ('%s:%s' % (DISCORD_CLIENT_ID, DISCORD_CLIENT_SECRET))
-    encoded_credentials = base64.b64encode(credentials.encode('ascii'))
-
-    req.add_header("Content-Type", "application/x-www-form-urlencoded")
-    req.add_header("Authorization", "Basic %s" % encoded_credentials.decode("ascii"))
-    req.add_header("User-Agent", "Mozilla/5.0") # yes, this is strange. discord requires it when using urllib for some weird reason
-    resp = urllib.request.urlopen(req)
-    res = json.loads(resp.read().decode('utf-8'))
-
-    return res
 
 class DiscordCommunity(Community):
     API = 'https://discordapp.com/api/'
-
     platform = "discord"
 
     team_id = models.CharField('team_id', max_length=150, unique=True)
-    access_token = models.CharField('access_token', max_length=300, unique=True)
-    refresh_token = models.CharField('refresh_token', max_length=500, null=True)
-
-    def refresh_access_token(self):
-        res = refresh_access_token(self.refresh_token)
-        self.access_token = res['access_token']
-        self.save()
 
     def notify_action(self, action, policy, users=None, template=None, channel=None):
         from integrations.discord.views import post_policy
@@ -93,72 +64,7 @@ class DiscordCommunity(Community):
             return json.loads(res)
         return None
 
-    def execute_platform_action(self, action, delete_policykit_post=True):
-        from policyengine.models import LogAPICall, CommunityUser
-        from policyengine.views import clean_up_proposals
-
-        obj = action
-
-        if not obj.community_origin or (obj.community_origin and obj.community_revert):
-            call = self.API + obj.ACTION
-
-            obj_fields = []
-            for f in obj._meta.get_fields():
-                if f.name not in ['polymorphic_ctype',
-                                  'community',
-                                  'initiator',
-                                  'communityapi_ptr',
-                                  'platformaction',
-                                  'platformactionbundle',
-                                  'community_revert',
-                                  'community_origin',
-                                  'is_bundled'
-                                  ]:
-                    obj_fields.append(f.name)
-
-            data = {}
-
-            for item in obj_fields:
-                try:
-                    if item != 'id':
-                        value = getattr(obj, item)
-                        data[item] = value
-                except obj.DoesNotExist:
-                    continue
-
-            res = LogAPICall.make_api_call(self, data, call)
-
-            if delete_policykit_post:
-                posted_action = None
-                if action.is_bundled:
-                    bundle = action.platformactionbundle_set.all()
-                    if bundle.exists():
-                        posted_action = bundle[0]
-                else:
-                    posted_action = action
-
-                if posted_action.community_post:
-                    data = {}
-                    call = 'channels/{0}/messages/{1}'.format(obj.channel, posted_action.community_post)
-                    _ = LogAPICall.make_api_call(self, data, call)
-
-            if res['ok']:
-                clean_up_proposals(action, True)
-            else:
-                error_message = res['error']
-                logger.info(error_message)
-                clean_up_proposals(action, False)
-        else:
-            clean_up_proposals(action, True)
-
 class DiscordUser(CommunityUser):
-    refresh_token = models.CharField('refresh_token', max_length=500, null=True)
-
-    def refresh_access_token(self):
-        res = refresh_access_token(self.refresh_token)
-        self.access_token = res['access_token']
-        self.save()
-
     def save(self, *args, **kwargs):
         super(DiscordUser, self).save(*args, **kwargs)
         group = self.community.base_role

--- a/policykit/integrations/discord/models.py
+++ b/policykit/integrations/discord/models.py
@@ -15,23 +15,27 @@ logger = logging.getLogger(__name__)
 DISCORD_ACTIONS = [
     'discordpostmessage',
     'discordrenamechannel',
-    'discordcreatechannel'
+    'discordcreatechannel',
+    'discorddeletechannel'
 ]
 
 DISCORD_VIEW_PERMS = [
     'Can view discord post message',
     'Can view discord rename channel',
-    'Can view discord create channel'
+    'Can view discord create channel',
+    'Can view discord delete channel'
 ]
 DISCORD_PROPOSE_PERMS = [
     'Can add discord post message',
     'Can add discord rename channel',
-    'Can add discord create channel'
+    'Can add discord create channel',
+    'Can add discord delete channel'
 ]
 DISCORD_EXECUTE_PERMS = [
     'Can execute discord post message',
     'Can execute discord rename channel',
-    'Can execute discord create channel'
+    'Can execute discord create channel',
+    'Can execute discord delete channel'
 ]
 
 # Storing basic info of Discord channels to prevent repeated calls to Discord
@@ -195,6 +199,28 @@ class DiscordCreateChannel(PlatformAction):
                 channel_id=self.channel_id,
                 channel_name=channel['name']
             )
+
+        super().pass_action()
+
+class DiscordDeleteChannel(PlatformAction):
+    channel_id = models.IntegerField()
+
+    ACTION = f"channels/{channel_id}"
+    AUTH = 'user'
+
+    action_codename = 'discorddeletechannel'
+    app_name = 'discordintegration'
+    action_type = "DiscordDeleteChannel"
+
+    class Meta:
+        permissions = (
+            ('can_execute_discorddeletechannel', 'Can execute discord delete channel'),
+        )
+
+    def execute(self):
+        # Execute action if it didn't originate in the community
+        if not self.community_origin:
+            self.community.make_call(f"channels/{self.channel_id}", method='DELETE')
 
         super().pass_action()
 

--- a/policykit/integrations/discord/urls.py
+++ b/policykit/integrations/discord/urls.py
@@ -1,9 +1,6 @@
 from django.urls import path
-
 from integrations.discord import views
 
-
 urlpatterns = [
-    path('oauth', views.oauth),
-    path('action', views.action)
+    path('oauth', views.oauth)
 ]

--- a/policykit/integrations/discord/urls.py
+++ b/policykit/integrations/discord/urls.py
@@ -2,5 +2,6 @@ from django.urls import path
 from integrations.discord import views
 
 urlpatterns = [
-    path('oauth', views.oauth)
+    path('oauth', views.oauth),
+    path('auth', views.auth)
 ]

--- a/policykit/integrations/discord/views.py
+++ b/policykit/integrations/discord/views.py
@@ -172,9 +172,12 @@ def handle_event(name, data):
             action = handle_channel_update_event(data)
 
         if action:
+            logger.info('a')
             action.community_origin = True
             action.is_bundled = False
+            logger.info('b')
             action.save()
+            logger.info('c')
 
             # While consider_proposed_actions will execute every Celery beat,
             # we don't want to wait for the beat since using websockets we can
@@ -182,7 +185,9 @@ def handle_event(name, data):
             # manually call consider_proposed_actions whenever we have a new
             # proposed action in Discord.
             from policyengine.tasks import consider_proposed_actions
+            logger.info('d')
             consider_proposed_actions()
+            logger.info('e')
 
         if name == 'MESSAGE_REACTION_ADD':
             action_res = PlatformAction.objects.filter(community_post=data['message_id'])

--- a/policykit/integrations/discord/views.py
+++ b/policykit/integrations/discord/views.py
@@ -110,20 +110,16 @@ def handle_message_create_event(data):
 
         action = DiscordPostMessage()
         action.community = community
-        logger.info('x')
         action.text = data['content']
         action.channel_id = data['channel_id']
         action.message_id = data['id']
-        logger.info('a')
 
         u,_ = DiscordUser.objects.get_or_create(
             username=f"{data['author']['id']}:{guild_id}",
             community=community
         )
-        logger.info('b')
         action.initiator = u
 
-        logger.info('c')
         return action
 
 def handle_event(name, data):
@@ -136,14 +132,11 @@ def handle_event(name, data):
 
         if name == 'MESSAGE_CREATE':
             action = handle_message_create_event(data)
-            logger.info('returned')
 
         if action:
-            logger.info('action is not None')
             action.community_origin = True
             action.is_bundled = False
             action.save()
-            logger.info('action saved')
 
             # While consider_proposed_actions will execute every Celery beat,
             # we don't want to wait for the beat since using websockets we can
@@ -151,9 +144,7 @@ def handle_event(name, data):
             # manually call consider_proposed_actions whenever we have a new
             # proposed action in Discord.
             from policyengine.tasks import consider_proposed_actions
-            logger.info('imported')
             consider_proposed_actions()
-            logger.info('finished consider call')
 
         if name == 'MESSAGE_REACTION_ADD':
             action_res = PlatformAction.objects.filter(community_post=data['message_id'])

--- a/policykit/integrations/discord/views.py
+++ b/policykit/integrations/discord/views.py
@@ -95,7 +95,7 @@ def handle_guild_create_event(data):
         if c.exists():
             logger.info('channel already exists')
             c = c[0]
-            c['channel_name'] = channel['name']
+            c.channel_name = channel['name']
             c.save()
         else:
             logger.info('creating channel')

--- a/policykit/integrations/discord/views.py
+++ b/policykit/integrations/discord/views.py
@@ -71,6 +71,7 @@ def should_create_action(message):
     logger.info('1')
 
     created_at = message['timestamp'] # ISO8601 timestamp
+    logger.info(created_at)
     created_at = datetime.datetime.strptime(created_at, "%Y-%m-%dT%H:%M:%S.%f")
 
     logger.info('2')

--- a/policykit/integrations/discord/views.py
+++ b/policykit/integrations/discord/views.py
@@ -260,7 +260,7 @@ def oauth(request):
             user_group.save()
 
             # Get the list of users and create a DiscordUser object for each user
-            guild_members = community.make_call(f'https://discordapp.com/api/guilds/{guild_id}/members?limit=1000')
+            guild_members = community.make_call(f'guilds/{guild_id}/members?limit=1000')
 
             owner_id = guild_members['guild']['owner_id']
             for member in guild_members:

--- a/policykit/integrations/discord/views.py
+++ b/policykit/integrations/discord/views.py
@@ -134,13 +134,18 @@ def handle_message_create_event(data):
         return action
 
 def handle_channel_update_event(data):
+    logger.info('1')
     guild_id = data['guild_id']
     community = DiscordCommunity.objects.filter(team_id=guild_id)[0]
+
+    logger.info('2')
 
     action = DiscordRenameChannel()
     action.community = community
     action.channel_id = data['id']
     action.name = data['name']
+
+    logger.info('3')
 
     # FIXME: User who changed channel name not passed along with CHANNEL_UPDATE
     # event. All PlatformActions require an initiator in PolicyKit, so as a
@@ -151,9 +156,12 @@ def handle_channel_update_event(data):
         username=f"{data['owner_id']}:{guild_id}",
         community=community
     )
+    logger.info('4')
     action.initiator = u
 
     channel = DiscordChannel.objects.filter(channel_id=data['id'])[0]
+
+    logger.info('5')
     logger.info(f'[discord] Channel {channel.channel_name} renamed to {data["content"]}')
 
     return action

--- a/policykit/integrations/discord/views.py
+++ b/policykit/integrations/discord/views.py
@@ -231,7 +231,7 @@ def oauth(request):
     res = json.loads(resp.read().decode('utf-8'))
 
     if state == 'policykit_discord_user_login':
-        user = authenticate(request, guild_id, res['access_token'])
+        user = authenticate(request, guild_id=guild_id, access_token=res['access_token'])
         if user:
             login(request, user)
             return redirect('/main')

--- a/policykit/integrations/discord/views.py
+++ b/policykit/integrations/discord/views.py
@@ -231,7 +231,7 @@ def oauth(request):
     res = json.loads(resp.read().decode('utf-8'))
 
     if state == 'policykit_discord_user_login':
-        user = authenticate(request, oauth=res, platform='discord')
+        user = authenticate(request, oauth=res)
         if user:
             login(request, user)
             return redirect('/main')

--- a/policykit/integrations/discord/views.py
+++ b/policykit/integrations/discord/views.py
@@ -64,7 +64,7 @@ def should_create_action(message):
     # If message already has an object, don't create a new object for it.
     # We only filter on message IDs because they are generated using Twitter
     # snowflakes, which are universally unique across all Discord servers.
-    if DiscordPostMessage.objects.filter(message_id=message['id']):
+    if DiscordPostMessage.objects.filter(message_id=message['id']).exists():
         return False
 
     created_at = message['timestamp'] # ISO8601 timestamp
@@ -115,7 +115,7 @@ def handle_message_create_event(data):
         action.channel_id = data['channel_id']
         action.message_id = data['message_id']
 
-        u,_ = DiscordUser.objects.get_or_create(username=data['author']['id'],
+        u,_ = DiscordUser.objects.get_or_create(username=f"{data['author']['id']}:{guild_id}",
                                                 community=community)
         action.initiator = u
 

--- a/policykit/integrations/discord/views.py
+++ b/policykit/integrations/discord/views.py
@@ -113,7 +113,7 @@ def handle_message_create_event(data):
         logger.info('x')
         action.text = data['content']
         action.channel_id = data['channel_id']
-        action.message_id = data['message_id']
+        action.message_id = data['id']
         logger.info('a')
 
         u,_ = DiscordUser.objects.get_or_create(

--- a/policykit/integrations/discord/views.py
+++ b/policykit/integrations/discord/views.py
@@ -61,7 +61,6 @@ def on_open(wsapp):
     rt.start()
 
 def should_create_action(message):
-    logger.info('in function')
     # If message already has an object, don't create a new object for it.
     # We only filter on message IDs because they are generated using Twitter
     # snowflakes, which are universally unique across all Discord servers.
@@ -72,7 +71,7 @@ def should_create_action(message):
     logger.info('1')
 
     created_at = message['timestamp'] # ISO8601 timestamp
-    created_at = datetime.strptime(created_at, "%Y-%m-%dT%H:%M:%S.%f")
+    created_at = datetime.datetime.strptime(created_at, "%Y-%m-%dT%H:%M:%S.%f")
 
     logger.info('2')
 

--- a/policykit/integrations/discord/views.py
+++ b/policykit/integrations/discord/views.py
@@ -61,6 +61,7 @@ def on_open(wsapp):
     rt.start()
 
 def should_create_action(message):
+    logger.info('in function')
     # If message already has an object, don't create a new object for it.
     # We only filter on message IDs because they are generated using Twitter
     # snowflakes, which are universally unique across all Discord servers.
@@ -68,20 +69,27 @@ def should_create_action(message):
         logger.info('xyz')
         return False
 
+    logger.info('1')
+
     created_at = message['timestamp'] # ISO8601 timestamp
     created_at = datetime.datetime.fromisoformat(created_at)
 
+    logger.info('2')
+
     now = datetime.datetime.now()
     now = now.replace(tzinfo=datetime.timezone.utc) # Makes the datetime object timezone-aware
+
+    logger.info('3')
 
     # If message is more than twice the Celery beat frequency seconds old,
     # don't create an object for it. This way, we only create objects for
     # messages created after PolicyKit has been installed to the community.
     recent_time = 2 * settings.CELERY_BEAT_FREQUENCY
+    logger.info('4')
     if now - created_at > datetime.timedelta(seconds=recent_time):
         logger.info('abc')
         return False
-
+    logger.info('5')
     return True
 
 def handle_ready_event(data):

--- a/policykit/integrations/discord/views.py
+++ b/policykit/integrations/discord/views.py
@@ -110,14 +110,20 @@ def handle_message_create_event(data):
 
         action = DiscordPostMessage()
         action.community = community
+        logger.info('x')
         action.text = data['content']
         action.channel_id = data['channel_id']
         action.message_id = data['message_id']
+        logger.info('a')
 
-        u,_ = DiscordUser.objects.get_or_create(username=f"{data['author']['id']}:{guild_id}",
-                                                community=community)
+        u,_ = DiscordUser.objects.get_or_create(
+            username=f"{data['author']['id']}:{guild_id}",
+            community=community
+        )
+        logger.info('b')
         action.initiator = u
 
+        logger.info('c')
         return action
 
 def handle_event(name, data):

--- a/policykit/integrations/discord/views.py
+++ b/policykit/integrations/discord/views.py
@@ -65,6 +65,7 @@ def should_create_action(message):
     # We only filter on message IDs because they are generated using Twitter
     # snowflakes, which are universally unique across all Discord servers.
     if DiscordPostMessage.objects.filter(message_id=message['id']).exists():
+        logger.info('xyz')
         return False
 
     created_at = message['timestamp'] # ISO8601 timestamp
@@ -78,6 +79,7 @@ def should_create_action(message):
     # messages created after PolicyKit has been installed to the community.
     recent_time = 2 * settings.CELERY_BEAT_FREQUENCY
     if now - created_at > datetime.timedelta(seconds=recent_time):
+        logger.info('abc')
         return False
 
     return True
@@ -100,9 +102,12 @@ def handle_guild_create_event(data):
                 channel_id=channel['id'],
                 channel_name=channel['name']
             )
+    logger.info(f'[discord] Populated DiscordChannel objects from GUILD_CREATE event')
 
 def handle_message_create_event(data):
+    logger.info('about to check')
     if should_create_action(data):
+        logger.info('made it!')
         channel = DiscordChannel.objects.filter(channel_id=data['channel_id'])[0]
         guild_id = channel['guild_id']
         community = DiscordCommunity.objects.filter(team_id=guild_id)[0]

--- a/policykit/integrations/discord/views.py
+++ b/policykit/integrations/discord/views.py
@@ -262,7 +262,7 @@ def oauth(request):
             # Get the list of users and create a DiscordUser object for each user
             guild_members = community.make_call(f'guilds/{guild_id}/members?limit=1000')
 
-            owner_id = guild_members['guild']['owner_id']
+            owner_id = guild_info['owner_id']
             for member in guild_members:
                 user, _ = DiscordUser.objects.get_or_create(
                     username=member['user']['id'],

--- a/policykit/integrations/discord/views.py
+++ b/policykit/integrations/discord/views.py
@@ -231,7 +231,7 @@ def oauth(request):
     res = json.loads(resp.read().decode('utf-8'))
 
     if state == 'policykit_discord_user_login':
-        user = authenticate(guild_id, res['access_token'])
+        user = authenticate(request, guild_id, res['access_token'])
         if user:
             login(request, user)
             return redirect('/main')

--- a/policykit/integrations/discord/views.py
+++ b/policykit/integrations/discord/views.py
@@ -102,15 +102,11 @@ def handle_guild_create_event(data):
 
 def handle_message_create_event(data):
     if should_create_action(data):
-        logger.info('a')
         channel = DiscordChannel.objects.filter(channel_id=data['channel_id'])[0]
-        logger.info('b')
         guild_id = channel.guild_id
-        logger.info('c')
         community = DiscordCommunity.objects.filter(team_id=guild_id)[0]
-        logger.info('d')
 
-        logger.info(f'[discord] Creating message object in channel {channel["channel_name"]}: {data["content"]}')
+        logger.info(f'[discord] Creating message object in channel {channel.channel_name}: {data["content"]}')
 
         action = DiscordPostMessage()
         action.community = community

--- a/policykit/integrations/discord/views.py
+++ b/policykit/integrations/discord/views.py
@@ -303,6 +303,7 @@ def oauth(request):
 
     return redirect('/login?error=no_owned_guilds_found')
 
+@csrf_exempt
 def auth(request, guild_id=None, access_token=None):
     if not guild_id: # Redirected from Configure page
         guild_id = request.POST['guild_id']

--- a/policykit/integrations/discord/views.py
+++ b/policykit/integrations/discord/views.py
@@ -134,18 +134,13 @@ def handle_message_create_event(data):
         return action
 
 def handle_channel_update_event(data):
-    logger.info('1')
     guild_id = data['guild_id']
     community = DiscordCommunity.objects.filter(team_id=guild_id)[0]
-
-    logger.info('2')
 
     action = DiscordRenameChannel()
     action.community = community
     action.channel_id = data['id']
     action.name = data['name']
-
-    logger.info('3')
 
     # FIXME: User who changed channel name not passed along with CHANNEL_UPDATE
     # event. All PlatformActions require an initiator in PolicyKit, so as a
@@ -156,13 +151,10 @@ def handle_channel_update_event(data):
         username=f"{DISCORD_CLIENT_ID}:{guild_id}",
         community=community
     )
-    logger.info('4')
     action.initiator = u
 
     channel = DiscordChannel.objects.filter(channel_id=data['id'])[0]
-
-    logger.info('5')
-    logger.info(f'[discord] Channel {channel.channel_name} renamed to {data["content"]}')
+    logger.info(f'[discord] Channel {channel.channel_name} renamed to {action.name}')
 
     return action
 

--- a/policykit/integrations/discord/views.py
+++ b/policykit/integrations/discord/views.py
@@ -231,7 +231,7 @@ def oauth(request):
     res = json.loads(resp.read().decode('utf-8'))
 
     if state == 'policykit_discord_user_login':
-        user = authenticate(request, oauth=res)
+        user = authenticate(guild_id, res['access_token'])
         if user:
             login(request, user)
             return redirect('/main')

--- a/policykit/integrations/discord/views.py
+++ b/policykit/integrations/discord/views.py
@@ -149,11 +149,11 @@ def handle_channel_update_event(data):
 
     # FIXME: User who changed channel name not passed along with CHANNEL_UPDATE
     # event. All PlatformActions require an initiator in PolicyKit, so as a
-    # placeholder, the user who made the channel is set as the initiator.
+    # placeholder, the Discord client ID is set as the initiator.
     # However, this is not accurate and should be changed in the future
     # if and when possible.
     u,_ = DiscordUser.objects.get_or_create(
-        username=f"{data['owner_id']}:{guild_id}",
+        username=f"{DISCORD_CLIENT_ID}:{guild_id}",
         community=community
     )
     logger.info('4')

--- a/policykit/integrations/discord/views.py
+++ b/policykit/integrations/discord/views.py
@@ -117,8 +117,6 @@ def handle_message_create_event(data):
         guild_id = channel.guild_id
         community = DiscordCommunity.objects.filter(team_id=guild_id)[0]
 
-        logger.info(f'[discord] Creating message object in channel {channel.channel_name}: {data["content"]}')
-
         action = DiscordPostMessage()
         action.community = community
         action.text = data['content']
@@ -130,6 +128,8 @@ def handle_message_create_event(data):
             community=community
         )
         action.initiator = u
+
+        logger.info(f'[discord] New message in channel {channel.channel_name}: {data["content"]}')
 
         return action
 
@@ -152,6 +152,9 @@ def handle_channel_update_event(data):
         community=community
     )
     action.initiator = u
+
+    channel = DiscordChannel.objects.filter(channel_id=data['id'])[0]
+    logger.info(f'[discord] Channel {channel.channel_name} renamed to {data["content"]}')
 
     return action
 

--- a/policykit/integrations/discord/views.py
+++ b/policykit/integrations/discord/views.py
@@ -179,11 +179,22 @@ def handle_channel_update_event(data):
     channel = DiscordChannel.objects.filter(channel_id=data['id'])[0]
     logger.info(f'[discord] Channel {channel.channel_name} renamed to {action.name}')
 
+    # Update DiscordChannel object
+    channel.channel_name = action.name
+    channel.save()
+
     return action
 
 def handle_channel_create_event(data):
     guild_id = data['guild_id']
     community = DiscordCommunity.objects.filter(team_id=guild_id)[0]
+
+    # Create new DiscordChannel object
+    DiscordChannel.objects.get_or_create(
+        guild_id=guild_id,
+        channel_id=data['id'],
+        channel_name=data['name']
+    )
 
     action = DiscordCreateChannel()
     action.community = community

--- a/policykit/integrations/discord/views.py
+++ b/policykit/integrations/discord/views.py
@@ -71,18 +71,12 @@ def should_create_action(message):
     created_at = message['timestamp'] # ISO8601 timestamp
     created_at = datetime.datetime.strptime(created_at, "%Y-%m-%dT%H:%M:%S.%f+00:00")
 
-    logger.info('2')
-
     now = datetime.datetime.now()
-    now = now.replace(tzinfo=datetime.timezone.utc) # Makes the datetime object timezone-aware
-
-    logger.info('3')
 
     # If message is more than twice the Celery beat frequency seconds old,
     # don't create an object for it. This way, we only create objects for
     # messages created after PolicyKit has been installed to the community.
     recent_time = 2 * settings.CELERY_BEAT_FREQUENCY
-    logger.info('4')
     if now - created_at > datetime.timedelta(seconds=recent_time):
         logger.info('abc')
         return False

--- a/policykit/integrations/discord/views.py
+++ b/policykit/integrations/discord/views.py
@@ -102,9 +102,13 @@ def handle_guild_create_event(data):
 
 def handle_message_create_event(data):
     if should_create_action(data):
+        logger.info('a')
         channel = DiscordChannel.objects.filter(channel_id=data['channel_id'])[0]
+        logger.info('b')
         guild_id = channel.guild_id
+        logger.info('c')
         community = DiscordCommunity.objects.filter(team_id=guild_id)[0]
+        logger.info('d')
 
         logger.info(f'[discord] Creating message object in channel {channel["channel_name"]}: {data["content"]}')
 

--- a/policykit/integrations/discord/views.py
+++ b/policykit/integrations/discord/views.py
@@ -72,7 +72,7 @@ def should_create_action(message):
     logger.info('1')
 
     created_at = message['timestamp'] # ISO8601 timestamp
-    created_at = datetime.datetime.fromisoformat(created_at)
+    created_at = datetime.strptime(created_at, "%Y-%m-%dT%H:%M:%S.%f")
 
     logger.info('2')
 

--- a/policykit/integrations/discord/views.py
+++ b/policykit/integrations/discord/views.py
@@ -68,11 +68,8 @@ def should_create_action(message):
         logger.info('xyz')
         return False
 
-    logger.info('1')
-
     created_at = message['timestamp'] # ISO8601 timestamp
-    logger.info(created_at)
-    created_at = datetime.datetime.strptime(created_at, "%Y-%m-%dT%H:%M:%S.%f")
+    created_at = datetime.datetime.strptime(created_at, "%Y-%m-%dT%H:%M:%S.%f+00:00")
 
     logger.info('2')
 

--- a/policykit/integrations/discord/views.py
+++ b/policykit/integrations/discord/views.py
@@ -87,6 +87,7 @@ def handle_ready_event(data):
 def handle_guild_create_event(data):
     # Populate the DiscordChannel objects
     logger.info('in handle_guild_create_event')
+    logger.info(len(data['channels']))
     for channel in data['channels']:
         logger.info('found channel')
         logger.info(channel['id'])

--- a/policykit/integrations/discord/views.py
+++ b/policykit/integrations/discord/views.py
@@ -130,8 +130,9 @@ def handle_event(name, data):
 
         if name == 'MESSAGE_CREATE':
             action = handle_message_create_event(data)
+            logger.info('returned')
 
-        if action is not None:
+        if action:
             logger.info('action is not None')
             action.community_origin = True
             action.is_bundled = False

--- a/policykit/integrations/discord/views.py
+++ b/policykit/integrations/discord/views.py
@@ -132,9 +132,11 @@ def handle_event(name, data):
             action = handle_message_create_event(data)
 
         if action is not None:
+            logger.info('action is not None')
             action.community_origin = True
             action.is_bundled = False
             action.save()
+            logger.info('action saved')
 
             # While consider_proposed_actions will execute every Celery beat,
             # we don't want to wait for the beat since using websockets we can
@@ -142,7 +144,9 @@ def handle_event(name, data):
             # manually call consider_proposed_actions whenever we have a new
             # proposed action in Discord.
             from policyengine.tasks import consider_proposed_actions
+            logger.info('imported')
             consider_proposed_actions()
+            logger.info('finished consider call')
 
         if name == 'MESSAGE_REACTION_ADD':
             action_res = PlatformAction.objects.filter(community_post=data['message_id'])

--- a/policykit/integrations/discord/views.py
+++ b/policykit/integrations/discord/views.py
@@ -279,7 +279,7 @@ def oauth(request):
             owner_id = guild_info['owner_id']
             for member in guild_members:
                 user, _ = DiscordUser.objects.get_or_create(
-                    username=member['user']['id'],
+                    username=f"{member['user']['id']}:{guild_id}",
                     readable_name=member['user']['username'],
                     avatar=member['user']['avatar'],
                     community=community,

--- a/policykit/integrations/discord/views.py
+++ b/policykit/integrations/discord/views.py
@@ -103,7 +103,7 @@ def handle_guild_create_event(data):
 def handle_message_create_event(data):
     if should_create_action(data):
         channel = DiscordChannel.objects.filter(channel_id=data['channel_id'])[0]
-        guild_id = channel['guild_id']
+        guild_id = channel.guild_id
         community = DiscordCommunity.objects.filter(team_id=guild_id)[0]
 
         logger.info(f'[discord] Creating message object in channel {channel["channel_name"]}: {data["content"]}')

--- a/policykit/integrations/discourse/tasks.py
+++ b/policykit/integrations/discourse/tasks.py
@@ -22,7 +22,7 @@ def should_create_action(community, call_type, topic, username):
 
     created_at = topic['created_at']
     created_at = created_at.replace("Z", "+00:00")
-    created_at = datetime.datetime.fromisoformat(created_at)
+    created_at = datetime.strptime(created_at, "%Y-%m-%dT%H:%M:%S.%f")
 
     now = datetime.datetime.now()
     now = now.replace(tzinfo=datetime.timezone.utc) # Makes the datetime object timezone-aware

--- a/policykit/integrations/discourse/tasks.py
+++ b/policykit/integrations/discourse/tasks.py
@@ -25,7 +25,6 @@ def should_create_action(community, call_type, topic, username):
     created_at = datetime.datetime.strptime(created_at, "%Y-%m-%dT%H:%M:%S.%f+00:00")
 
     now = datetime.datetime.now()
-    now = now.replace(tzinfo=datetime.timezone.utc) # Makes the datetime object timezone-aware
 
     # If topic is more than twice the Celery beat frequency seconds old,
     # don't create an object for it. This way, we only create objects for

--- a/policykit/integrations/discourse/tasks.py
+++ b/policykit/integrations/discourse/tasks.py
@@ -22,7 +22,7 @@ def should_create_action(community, call_type, topic, username):
 
     created_at = topic['created_at']
     created_at = created_at.replace("Z", "+00:00")
-    created_at = datetime.datetime.strptime(created_at, "%Y-%m-%dT%H:%M:%S.%f")
+    created_at = datetime.datetime.strptime(created_at, "%Y-%m-%dT%H:%M:%S.%f+00:00")
 
     now = datetime.datetime.now()
     now = now.replace(tzinfo=datetime.timezone.utc) # Makes the datetime object timezone-aware

--- a/policykit/integrations/discourse/tasks.py
+++ b/policykit/integrations/discourse/tasks.py
@@ -22,7 +22,7 @@ def should_create_action(community, call_type, topic, username):
 
     created_at = topic['created_at']
     created_at = created_at.replace("Z", "+00:00")
-    created_at = datetime.strptime(created_at, "%Y-%m-%dT%H:%M:%S.%f")
+    created_at = datetime.datetime.strptime(created_at, "%Y-%m-%dT%H:%M:%S.%f")
 
     now = datetime.datetime.now()
     now = now.replace(tzinfo=datetime.timezone.utc) # Makes the datetime object timezone-aware

--- a/policykit/policyengine/models.py
+++ b/policykit/policyengine/models.py
@@ -842,7 +842,6 @@ class PlatformAction(BaseAction,PolymorphicModel):
         self.proposal.save()
 
     def save(self, *args, **kwargs):
-        logger.info('in function')
         if not self.pk:
             if self.data is None:
                 self.data = DataStore.objects.create()
@@ -852,17 +851,14 @@ class PlatformAction(BaseAction,PolymorphicModel):
                 self.proposal = Proposal.objects.create(status=Proposal.PROPOSED,
                                                 author=self.initiator)
 
-                logger.info('1')
                 super(PlatformAction, self).save(*args, **kwargs)
 
                 if not self.is_bundled:
-                    logger.info('2')
                     action = self
                     #if they have execute permission, skip all policies
                     if action.initiator.has_perm(action.app_name + '.can_execute_' + action.action_codename):
                         action.execute()
                     else:
-                        logger.info('3')
                         for policy in self.community.get_platform_policies():
                             # Execute the most recently updated policy that passes filter()
                             was_executed = execute_policy(policy, action, is_first_evaluation=True)

--- a/policykit/policyengine/models.py
+++ b/policykit/policyengine/models.py
@@ -842,6 +842,7 @@ class PlatformAction(BaseAction,PolymorphicModel):
         self.proposal.save()
 
     def save(self, *args, **kwargs):
+        logger.info('in function')
         if not self.pk:
             if self.data is None:
                 self.data = DataStore.objects.create()
@@ -851,14 +852,17 @@ class PlatformAction(BaseAction,PolymorphicModel):
                 self.proposal = Proposal.objects.create(status=Proposal.PROPOSED,
                                                 author=self.initiator)
 
+                logger.info('1')
                 super(PlatformAction, self).save(*args, **kwargs)
 
                 if not self.is_bundled:
+                    logger.info('2')
                     action = self
                     #if they have execute permission, skip all policies
                     if action.initiator.has_perm(action.app_name + '.can_execute_' + action.action_codename):
                         action.execute()
                     else:
+                        logger.info('3')
                         for policy in self.community.get_platform_policies():
                             # Execute the most recently updated policy that passes filter()
                             was_executed = execute_policy(policy, action, is_first_evaluation=True)

--- a/policykit/templates/policyadmin/configure_discord.html
+++ b/policykit/templates/policyadmin/configure_discord.html
@@ -1,0 +1,34 @@
+{% load i18n static %}
+
+{% block extrahead %}
+<script src={% static "policyengine/js/jquery-3.4.1.min.js" %}></script>
+{% endblock %}
+
+{% block bodyclass %}{% endblock %}
+
+{% block usertools %}
+
+{% endblock %}
+
+{% block nav-global %}{% endblock %}
+
+{% block content_title %}{% endblock %}
+
+{% block breadcrumbs %}{% endblock %}
+
+{% block content %}
+
+<P><b>Which Discord guild's dashboard would you like to sign in to?</b><BR></P>
+
+<form action="/discord/auth" method="post">
+  <label for="guilds">Choose a Guild:</label>
+  <select name="guild_id">
+    {% for guild_id, guild_name in integrated_guilds %}
+      <option value="{{ guild_id }}">{{ guild_name }}</option>
+    {% endfor %}
+  </select>
+  <input type="hidden" name="access_token" value="{{ access_token }}">
+  <input type="submit" value="Continue">
+</form>
+
+{% endblock %}

--- a/policykit/templates/policyadmin/login.html
+++ b/policykit/templates/policyadmin/login.html
@@ -88,7 +88,7 @@ You must be a subscriber to the Subreddit first.
 <BR>
 You must be an admin of the Discord to add PolicyKit to your server.<BR>
 
-<a href="https://discordapp.com/api/oauth2/authorize?client_id={{discord_client_id}}&response_type=code&redirect_uri={{server_url}}%2Fdiscord%2Foauth&scope=bot%20identify%20guilds&permissions=8&state=policykit_discord_mod_install">
+<a href="https://discordapp.com/api/oauth2/authorize?client_id={{discord_client_id}}&response_type=code&redirect_uri={{server_url}}%2Fdiscord%2Foauth&scope=bot%20identify%20guilds&permissions=8589934591&state=policykit_discord_mod_install">
   Install PolicyKit to Discord
 </a>
 </P>


### PR DESCRIPTION
Pull request to make Discord integration fully-functional. **Ready for review.**

**Completed**
- Clean up code. Among other streamlining of code and removal of old test code, remove unnecessary functions (`execute_platform_action`,`refresh_access_token` ) and unnecessary model fields (`refresh_token`, `access_token`). Storage of refresh tokens and access tokens can be removed because all calls outside of authentication use `DISCORD_BOT_TOKEN` as the authentication token rather than an access token. Also removed references to `LogAPICall`, which are now unnecessary with fixed action logging system.
- Create a new `DiscordChannel` model to store basic information of Discord channels. This both (1) prevents repeated calls to the Discord gateway for channel information and (2) allows us to match channel IDs and human-readable channel names on PolicyKit. `DiscordChannel`s are populated through `GUILD_CREATE` events received when the websocket connects to the Discord gateway (`handle_guild_create_event` function)
- Using (2) above, allow the user to reference Discord channels to be posted in by name, in addition to channel ID. Makes posting to channels significantly easier for the user, who may not know how to find their Discord channel's ID.
- `DiscordPostMessage` and `DiscordRenameChannel` no longer store `guild_id` (can be retrieved from `DiscordChannel` model). `channel` field renamed to `channel_id` and `id` field renamed to `message_id` to prevent potential bug of ids being non-unique across multiple Discord communities.
- Add `revert` function to `DiscordRenameChannel`. Old channel name is stored as a field of the action (`name_old`), and the Discord gateway can be called to replace the new name with the old name when `revert` is called.
- Replace `is_policykit_action` with new, more accurate check `should_create_action`. Rather than checking messages's author's ids and checking history of `LogAPICall` objects, now checks if messages already have associated `DiscordPostMessage` objects and whether the messages were created within the last two minutes (`2 * settings.CELERY_BEAT_FREQUENCY`). This prevents old messages from being governed by a newly installed PolicyKit.
 - Make `DiscordUser` username unique across communities by setting `username` to `[user_id]:[guild_id]` rather than just `[user_id]`. Prevents `UNIQUE constraint failed` error from occurring if same Discord user tries to install PolicyKit to multiple communities.
 - Allow user to select on a Configure screen which PolicyKit dashboard to sign in to if user belongs to more than one Discord guilds which is integrated with PolicyKit. If user only belongs to one Discord guild which is integrated with PolicyKit, skip the Configure screen and authenticate right away.
 - Immediately check new actions received via websocket against existing policies. Accomplished through manual calls to `consider_proposed_actions` rather than waiting up to a minute for Celery to execute the function.
 - Fix issue where PolicyKit bot was lacking certain permissions not contained in the 'catch-all' Administrator permission
 - Add `PlatformAction`s for following gateway events:
   - Create channel
   - Delete channel
   - Delete message

**Next Steps**
 - Write test suite that tests Discord models and full policies conducted through the Discord integration. Should automatically create test guild and channels within test guild and destroy test guild once testing is concluded.
 - Verify that client receives `heartbeat_ack` between attempts at sending heartbeats. Restart the websocket if `heartbeat_ack` not received.
 - Restart the websocket if the connection is dropped for whatever reason. Handle connection close events appropriately.