### PR TITLE
Only use polling to get MetagovProcess updates, not callback URLs

### DIFF
--- a/docs/source/integrations.rst
+++ b/docs/source/integrations.rst
@@ -165,8 +165,8 @@ Use the ``metagov`` client to perform asynchronous governance processes. Here's 
 
     # "check" block polls for the process outcome
 
-    result = metagov.get_process_outcome()
-    if result is None:
+    result = metagov.get_process()
+    if result.status != "completed":
         return # still processing
     if result.errors:
         return FAILED

--- a/policykit/policyengine/filter.py
+++ b/policykit/policyengine/filter.py
@@ -43,7 +43,7 @@ whitelisted_modules = {
     "metagov": [
         "start_process",
         "close_process",
-        "get_process_outcome",
+        "get_process",
         "perform_action",
     ],
     "base64": [


### PR DESCRIPTION
* Stop using the `callback_url` functionality for Metagov right now, because PK is doing both polling _and_ listening to callbacks, and which is far too confusing and unnecessary. See here about the  `callback_url` param https://docs.metagov.org/en/latest/driver_tutorial.html#push-approach. 
* Some small changes to the internals of the `Metagov` library so the code is easier to reason about
* Only instantiate one `Metagov` client per policy execution, instead of once for each function (initialize/filter.etc) see `views.py`
* Rename `get_process_outcome` to `get_process` 