### PR TITLE
Fix readthedocs build by defaulting to logging in base directory

### DIFF
--- a/policykit/.gitignore
+++ b/policykit/.gitignore
@@ -6,3 +6,4 @@ static/*
 .DS_Store
 env
 .vscode
+*.log

--- a/policykit/policykit/settings.py
+++ b/policykit/policykit/settings.py
@@ -168,6 +168,9 @@ STATIC_ROOT = os.path.join(BASE_DIR, 'static/')
 
 PROJECT_NAME = "PolicyKit"
 
+# Override this value in production (For example: "/var/log/django")
+LOGGING_ROOT_DIR = BASE_DIR
+
 LOGGING = {
     'version': 1,
     'disable_existing_loggers': False,
@@ -175,7 +178,7 @@ LOGGING = {
         'file': {
             'level': 'DEBUG',
             'class': 'logging.FileHandler',
-            'filename': '/var/log/django/debug.log',
+            'filename': os.path.join(LOGGING_ROOT_DIR, 'django.log'),
         },
     },
     'loggers': {


### PR DESCRIPTION
The readthedocs build is broken because Django setup required the `/var/log/django/` directory to exist: https://readthedocs.org/projects/policykit/builds/13641338/

Change the default to place `debug.log` into the base directory. In prod it can be overriden to any path. There is probably a more elegant way to do do the logging configuration.
