### PR TITLE
Fix sphinx build again

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -15,13 +15,13 @@ import sys
 import django
 import sphinx_rtd_theme
 
-sys.path.insert(0, os.path.abspath('../../policykit'))
+policykit_path = os.path.abspath('../../policykit')
+sys.path.insert(0, policykit_path)
 
+os.environ.setdefault('PRIVATE_FILE_PATH', policykit_path + '/private_template.py')
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'policykit.settings')
-os.environ.setdefault('DJANGO_SECRET_KEY', 'kg=&9zrc5@rern2=&+6yvh8ip0u7$f=k_zax**bwsur_z7qy+-') # test key
 
 django.setup()
-
 
 # -- Project information -----------------------------------------------------
 

--- a/policykit/policykit/settings.py
+++ b/policykit/policykit/settings.py
@@ -15,10 +15,11 @@ import os
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
+PRIVATE_FILE_PATH = os.environ.get("PRIVATE_FILE_PATH", BASE_DIR + "/private.py")
 try:
-    exec(open(BASE_DIR + '/private.py').read())
+    exec(open(PRIVATE_FILE_PATH).read())
 except IOError:
-    print("Unable to open configuration file!")
+    raise Exception(f"Unable to open configuration file at: '{PRIVATE_FILE_PATH}'")
 
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/3.0/howto/deployment/checklist/


### PR DESCRIPTION
Sphinx build is now failing with a new error because there is no `private.py` file present https://readthedocs.org/projects/policykit/builds/13670098/
I fixed it by having the docs build use the `private_template.py` file as the actual private file. Tested sphinx build commands locally, I'm pretty sure this will fix it.