### PR TITLE
Stop storing celery task results in the database

### DIFF
--- a/policykit/policykit/celery.py
+++ b/policykit/policykit/celery.py
@@ -23,6 +23,8 @@ app.config_from_object('django.conf:settings', namespace='CELERY')
 # Load task modules from all registered Django app configs.
 app.autodiscover_tasks()
 
+# Don't store task results in the database
+app.conf.task_ignore_result = True
 
 @app.task(bind=True)
 def debug_task(self):


### PR DESCRIPTION
We don't use these task results, so we shouldn't store them in the database (currently they're in table `django_celery_results_taskresult`).