### PR TITLE
Update PolicyKit deployment instructions to work with Metagov

### DIFF
--- a/docs/source/gettingstarted.rst
+++ b/docs/source/gettingstarted.rst
@@ -160,37 +160,45 @@ Make sure you have a domain dedicated to Policykit that is pointing to your serv
 
 4. Test your config with ``apache2ctl configtest``. You should get a "Syntax OK" as a response. 
 
-5. Get an SSL certificate and set it up to auto-renew using LetsEncrypt. Follow steps 1 and 4 here: `How To Secure Apache with Let's Encrypt on Ubuntu 20.04 <https://www.digitalocean.com/community/tutorials/how-to-secure-apache-with-let-s-encrypt-on-ubuntu-20-04>`_. Once that's done, add the newly created SSL files to your apache2 conf:
+5. Enable your site:
+
+        .. code-block:: shell
+
+                # activate your config
+                a2ensite /etc/apache2/sites-available/$SERVER_NAME.conf
+
+                # disable the default config
+                sudo a2dissite 000-default-le-ssl.conf
+
+6. Get an SSL certificate and set it up to auto-renew using LetsEncrypt:
+
+    .. code-block:: shell
+
+        sudo apt install certbot python3-certbot-apache
+        sudo certbot --apache
+
+7. Add the certificates to your ``$SERVER_NAME.conf`` file:
 
     .. code-block:: aconf
 
         SSLCertificateFile /etc/letsencrypt/live/$SERVER_NAME/fullchain.pem
         SSLCertificateKeyFile /etc/letsencrypt/live/$SERVER_NAME/privkey.pem
 
-6. Activate the site:
+8. Reload the config:
 
-        .. code-block:: shell
+     .. code-block:: shell
 
-             # activate your config
-             a2ensite /etc/apache2/sites-available/$SERVER_NAME.conf
+          systemctl reload apache2
 
-             # disable the default config
-             sudo a2dissite 000-default-le-ssl.conf
 
-             # you should see a symlink to your site config here:
-             ls /etc/apache2/sites-enabled
-
-             # activate the new configuration
-             systemctl reload apache2
-
-7. Give the Apache2 user access to the database directory and the logging directory (update paths as needed):
+9.  Give the Apache2 user access to the database directory and the logging directory (update paths as needed):
 
         .. code-block:: shell
 
                 sudo chown -R www-data:www-data /var/log/django
                 sudo chown -R www-data:www-data /var/databases/policykit
 
-8. Load your site in the browser and navigate to ``/main``. You should see a site titled "Django adminstration" with options to connect to Slack, Reddit, Discourse, and Discord. Before you can install PolicyKit into any of these platforms, you'll need to set the necessary client IDs and client in ``private.py``. Follow the setup instructions for each integration in :doc:`Integrations <../integrations>`.
+10. Load your site in the browser and navigate to ``/main``. You should see a site titled "Django adminstration" with options to connect to Slack, Reddit, Discourse, and Discord. Before you can install PolicyKit into any of these platforms, you'll need to set the necessary client IDs and client in ``private.py``. Follow the setup instructions for each integration in :doc:`Integrations <../integrations>`.
 
   Check for errors at ``/var/log/apache2/error.log`` and ``/var/log/django/debug.log`` (or whatever logging path you have defined in ``settings.py``).
 

--- a/docs/source/gettingstarted.rst
+++ b/docs/source/gettingstarted.rst
@@ -6,7 +6,7 @@ Installation and Getting Started
 | On this page, we will take you through the process of setting up PolicyKit, both for development and for production.
 
 Getting Started
-~~~~~~~~~~~~~~~~~
+---------------
 
 | PolicyKit requires Python 3. Before you install, we recommend that you activate a Python 3+ virtual environment.
 
@@ -60,26 +60,35 @@ From the shell prompt, run the following command to create the starterkits:
 Open PolicyKit in the browser at http://localhost:8000/main
 
 Troubleshooting
----------------------------
+^^^^^^^^^^^^^^^
 
 | It's possible that you may receive the error ``InvalidBasesError: Cannot resolve bases for [<ModelState: 'users.GroupProxy'>]`` where ``ModelState`` may refer to ``policyengine``, ``policykit``, ``slack``, ``reddit``, ``discord`` or ``discourse``. If so, inside each referenced directory, make sure that there exists a subdirectory named ``migrations`` containing an empty file named ``__init__.py``.
 
 | It's possible that when you try to make migrations, you may receive an error of the form ``ImportError: cannot import name 'FieldDoesNotExist'``. If you receive this error, then you need to go to ``/site-packages/polymorphic/query.py`` and change the line ``django.db.models import FieldDoesNotExist`` to ``from django.core.exceptions import FieldDoesNotExist``.
 
 Running PolicyKit in Production
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+-------------------------------
 
-| Initialize a webserver. Thus far, we have been run in Ubuntu 18.04 and Ubuntu 20.04, and the below instructions should work for both.
+| Thus far, we have been run in Ubuntu 18.04 and Ubuntu 20.04, and the below instructions should work for both.
 
 | Add PolicyKit to the server by uploading the codebase or using ``git clone``. Create a virtualenv and install all requirements into the virtualenv as above. For instructions, see `this guide <https://www.digitalocean.com/community/tutorials/how-to-install-python-3-and-set-up-a-programming-environment-on-an-ubuntu-20-04-server>`_.
 
-| Once you have finished following the earlier guide to setting up PolicyKit you need to make the following additional changes:
-
-- Update the ``ALLOWED_HOSTS`` field in ``settings.py`` to point to your hosts.
+| Once you have finished following the earlier guide to setting up PolicyKit, you need to make the following additional changes:
 
 - Update the ``SERVER_URL`` field in ``private.py``, and fill in any necessary API keys/secrets.
 
-- Verify that the database path in ``settings.py`` is correct. It is not recommended to keep the database inside the project directory, because you need to grant the apache2 user (``www-data``) access to the database its parent folder. Recommended: put the database somewhere like ``/var/databases/policykit/db.sqlite3``.
+- Update the ``ALLOWED_HOSTS`` field in ``settings.py`` to point to your host.
+
+- Update that the database path in ``settings.py`` under ``DATABASES``. It is not recommended to keep the database inside the project directory, because the apache2 user (www-data) needs write access to the database *and* it's parent folder. Recommended: put the database in ``/var/databases/policykit/db.sqlite3``.
+
+- Update the ``LOGGING_ROOT_DIR``in ``settings.py`` to point to your log directory (for example ``/var/log/django``).
+
+- Generate a new Django secret key and put it in ``settings.py``. Generate a key with this command:
+
+        .. code-block::
+
+                python manage.py shell -c 'from django.core.management import utils; print(utils.get_random_secret_key())'
+
 
 | Next, run the following command to collect static files into a ``static/`` folder:
 
@@ -87,156 +96,247 @@ Running PolicyKit in Production
 
  python manage.py collectstatic
 
-| Run the following command to install Apache2 and the ``mod-wsgi`` package:
 
-::
+Deploy with Apache web server
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
- sudo apt-get install apache2 libapache2-mod-wsgi-py3
+Now that you have PolicyKit installed on your server, you can deploy it on Apache web server.
+Make sure you have a domain dedicated to Policykit that is pointing to your server's IP address.
 
-| Configure Apache2 by editing ``/etc/apache2/sites-available/000-default.conf``. Note: By default, this config file assumes the code is at ``/policykit`` and the virtualenv is at ``/policykit_vm``.
+.. note::
 
-| File: ``000-default.conf``
+        In the remaining examples, make sure to substitute the following values:
 
-::
+        ``$POLICYKIT_REPO`` is the path to your policykit repository root. (``/policykit``)
 
- <VirtualHost *:80>
-        Alias /static /policykit/policykit/static
-        <Directory /policykit/policykit/static>
-                Require all granted
-        </Directory>
+        ``$POLICYKIT_ENV`` is the path to your policykit virtual environment. (``/environments/policykit_env``)
 
-        <Directory /policykit/policykit/policykit>
-                <Files wsgi.py>
-                        Require all granted
-                </Files>
-        </Directory>
+        ``$SERVER_NAME`` is  your server name. (``policykit.mysite.com``)
 
-        WSGIDaemonProcess policykit python-home=/policykit_vm python-path=/policykit/policykit
-        WSGIProcessGroup policykit
-        WSGIScriptAlias / /policykit/policykit/policykit/wsgi.py
+1. Install apache2
 
- ...more below
+   .. code-block:: shell
 
-| You may separately wish to configure PolicyKit to work under HTTPS (will be neccesary to interface with the Slack API for instance). If so, you'll need to get an SSL certificate (we use LetsEncrypt) and add the following file under ``/etc/apache2/sites-available/default-ssl.conf``. You may want to redirect HTTP calls to HTTPS - if so, you'll need to update the :80 config above. `Instructions to set up LetsEncrypt on ubuntu 20.04 <https://www.digitalocean.com/community/tutorials/how-to-secure-apache-with-let-s-encrypt-on-ubuntu-20-04>`_.
+        sudo apt-get install apache2 libapache2-mod-wsgi-py3
 
-::
+2. Create a new apache2 config file:
 
- #<IfModule mod_ssl.c>
-        <VirtualHost *:443>
-                Alias /static /policykit/policykit/static
-                <Directory /policykit/policykit/static>
-                        Require all granted
-                </Directory>
+   .. code-block:: shell
 
-                <Directory /policykit/policykit/policykit>
-                        <Files wsgi.py>
+        cd /etc/apache2/sites-available
+        # replace SERVER_NAME (ie policykit.mysite.com.conf)
+        cp default-ssl.conf SERVER_NAME.conf
+
+3. Edit the config file to look like this:
+
+
+   .. code-block:: aconf
+
+        <IfModule mod_ssl.c>
+                <VirtualHost _default_:443>
+                        ServerName $SERVER_NAME
+                        ServerAdmin webmaster@localhost
+                        Alias /static $POLICYKIT_REPO/policykit/static
+
+                        <Directory $POLICYKIT_REPO/policykit/static>
                                 Require all granted
-                        </Files>
-                </Directory>
+                        </Directory>
 
-                WSGIDaemonProcess policykitssl python-home=/policykit_vm python-path=/policykit/policykit
-                WSGIProcessGroup policykitssl
-                WSGIScriptAlias / /policykit/policykit/policykit/wsgi.py
+                        # Grant access to wsgi.py file. This is the Django server.
+                        <Directory $POLICYKIT_REPO/policykit/policykit>
+                                <Files wsgi.py>
+                                        Require all granted
+                                </Files>
+                        </Directory>
 
-                SSLEngine on
-                SSLCertificateFile      /etc/letsencrypt/live/policykit.org/fullchain.pem
-                SSLCertificateKeyFile /etc/letsencrypt/live/policykit.org/privkey.pem
+                        WSGIDaemonProcess policykit python-home=$POLICYKIT_ENV python-path=$POLICYKIT_REPO/policykit
+                        WSGIProcessGroup policykit
+                        WSGIScriptAlias / $POLICYKIT_REPO/policykit/policykit/wsgi.py
+                        # .. REST ELIDED
+                </VirtualHost>
+        </IfModule>
 
- ...more below
+4. Test your config with ``apache2ctl configtest``
 
-| Run the following commands to install ``RabbitMQ`` and ``celery``:
+5. Get an SSL certificate and set it up to auto-renew using LetsEncrypt. Follow step 4 here: `How To Secure Apache with Let's Encrypt on Ubuntu 20.04 <https://www.digitalocean.com/community/tutorials/how-to-secure-apache-with-let-s-encrypt-on-ubuntu-20-04>`_. Once that's done, add the newly created SSL files to your apache2 conf:
 
-::
+    .. code-block:: aconf
 
- sudo apt-get install rabbitmq-server
- pip install celery
+        SSLCertificateFile /etc/letsencrypt/live/$SERVER_NAME/fullchain.pem
+        SSLCertificateKeyFile /etc/letsencrypt/live/$SERVER_NAME/privkey.pem
 
-| Next, we need to create these configuration files for running ``celery`` and ``celery-beat`` as a process:
+6. Activate the site:
 
-| File: ``/etc/systemd/system/celery.service``
+        .. code-block:: shell
 
-::
+             a2ensite /etc/apache2/sites-available/$SERVER_NAME.conf
+             # you should see a symlink to your site config here:
+             ls /etc/apache2/sites-enabled
 
- [Unit]
- Description=Celery Service
- After=network.target
+7. Load your site in the browser.
 
- [Service]
- Type=forking
- User=ubuntu
- Group=ubuntu
- EnvironmentFile=/etc/conf.d/celery
- WorkingDirectory=/policykit/policykit
- ExecStart=/bin/sh -c '${CELERY_BIN} multi start ${CELERYD_NODES} \
-   -A ${CELERY_APP} --pidfile=${CELERYD_PID_FILE} \
-   --logfile=${CELERYD_LOG_FILE} --loglevel=${CELERYD_LOG_LEVEL} ${CELERYD_OPTS}'
- ExecStop=/bin/sh -c '${CELERY_BIN} multi stopwait ${CELERYD_NODES} \
-   --pidfile=${CELERYD_PID_FILE}'
- ExecReload=/bin/sh -c '${CELERY_BIN} multi restart ${CELERYD_NODES} \
-   -A ${CELERY_APP} --pidfile=${CELERYD_PID_FILE} \
-   --logfile=${CELERYD_LOG_FILE} --loglevel=${CELERYD_LOG_LEVEL} ${CELERYD_OPTS}'
+  Check for errors at ``/var/log/apache2/error.log`` and ``/var/log/django/debug.log`` (or whatever logging path you have defined in ``settings.py``). The ``www-data`` user should own the Django log directory and have write-access to the log file.
 
- [Install]
- WantedBy=multi-user.target
+8. Any time you update the code, you'll need to run ``systemctl reload apache2`` to reload the server.
 
-| File: ``/etc/systemd/system/celerybeat.service``
+Set up Celery
+^^^^^^^^^^^^^
 
-::
+PolicyKit uses `Celery <https://docs.celeryproject.org/en/stable/index.html>`_ to run scheduled tasks.
+Follow these instructions to run a celery daemon on your Ubuntu machine using ``systemd``.
+For more information about configuration options, see the `Celery Daemonization <https://docs.celeryproject.org/en/stable/userguide/daemonizing.html>`_.
 
- [Unit]
- Description=Celery Beat Service
- After=network.target
+.. note::
 
- [Service]
- Type=simple
- User=ubuntu
- Group=ubuntu
- EnvironmentFile=/etc/conf.d/celery
- WorkingDirectory=/policykit/policykit
- ExecStart=/bin/sh -c '${CELERY_BIN} beat  \
-   -A ${CELERY_APP} --pidfile=${CELERYBEAT_PID_FILE} \
-   --logfile=${CELERYBEAT_LOG_FILE} --loglevel=${CELERYD_LOG_LEVEL}'
+        Using PolicyKit with Metagov? These configuration files are designed specifically to work with the setup where PolicyKit and Metagov are deployed together.
+        PolicyKit and Metagov will use separate celery daemons that use separate RabbitMQ virtual hosts, configured using ``CELERY_BROKER_URL``.
 
- [Install]
- WantedBy=multi-user.target
 
-| You can see both point to an environment file. Add the following file. You can change the arguments to suit your needs. Make sure to update the path to Celery bin according to your virtual environment.
+Create RabbitMQ virtual host
+""""""""""""""""""""""""""""
 
-| File: ``/etc/conf.d/celery``
+Install RabbitMQ:
 
-::
+.. code-block:: shell
 
- # Name of nodes to start
- # we have one node:
- CELERYD_NODES="w1"
+    sudo apt-get install rabbitmq-server
 
- # Absolute or relative path to the 'celery' command:
- CELERY_BIN="/policykit_vm/bin/celery"
+Follow these instruction to `create a RabbitMQ username, password, and virtual host <https://docs.celeryproject.org/en/stable/getting-started/brokers/rabbitmq.html#setting-up-rabbitmq>`_.
 
- # App instance to use
- # comment out this line if you don't use an app
- CELERY_APP="policykit"
- # or fully qualified:
- #CELERY_APP="proj.tasks:app"
+In ``policykit/settings.py``, set the ``CELERY_BROKER_URL`` as follows, substituting values for your RabbitMQ username, password, and virtual host:
 
- # How to call manage.py
- CELERYD_MULTI="multi"
+.. code-block:: python
 
- # Extra command-line arguments to the worker
- CELERYD_OPTS="--time-limit=300 --concurrency=8"
+    CELERY_BROKER_URL = "amqp://USERNAME:PASSWORD@localhost:5672/VIRTUALHOST"
 
- # - %n will be replaced with the first part of the nodename.
- # - %I will be replaced with the current child process index
- #   and is important when using the prefork pool to avoid race conditions.
- CELERYD_PID_FILE="/var/run/celery/%n.pid"
- CELERYD_LOG_FILE="/var/log/celery/%n%I.log"
- CELERYD_LOG_LEVEL="INFO"
+Create celery user
+""""""""""""""""""
 
- # you may wish to add these options for Celery Beat
- CELERYBEAT_PID_FILE="/var/run/celery/beat.pid"
- CELERYBEAT_LOG_FILE="/var/log/celery/beat.log"
+If you don't already have a ``celery`` user, create one:
 
-| See `Celery 4.4.0 docs for daemonization using systemd <https://docs.celeryproject.org/en/4.4.0/userguide/daemonizing.html#usage-systemd>`_ for more information.
+.. code-block:: bash
+
+        sudo useradd celery -d /home/celery -b /bin/bash
+
+Give the ``celery`` user access to necessary pid and log folders:
+
+.. code-block:: bash
+
+        sudo useradd celery -d /home/celery -b /bin/bash
+        sudo mkdir /var/log/celery
+        sudo chown -R celery:celery /var/log/celery
+        sudo chmod -R 755 /var/log/celery
+
+        sudo mkdir /var/run/celery
+        sudo chown -R celery:celery /var/run/celery
+        sudo chmod -R 755 /var/run/celery
+
+The ``celery`` user will also need write access to the Django log file and the database.
+To give ``celery`` access, create a group that contains both ``www-data`` (the apache2 user) and ``celery``.
+For example, if your Django logs are in ``/var/log/django`` and your database is in ``/var/databases``:
+
+.. code-block:: bash
+
+        sudo groupadd www-and-celery
+        sudo usermod -a -G www-and-celery celery
+        sudo usermod -a -G www-and-celery www-data
+
+        # give the group read-write access to logs
+        sudo chgrp -R www-and-celery /var/log/django
+        sudo chmod -R 775 /var/log/django
+
+        # give the group read-write access to database
+        sudo chgrp -R www-and-celery /var/databases
+        sudo chmod -R 775 /var/databases
+
+
+Create Celery configuration files
+"""""""""""""""""""""""""""""""""
+
+Next, you'll need to create three Celery configuration files for PolicyKit:
+
+``/etc/conf.d/celery-policykit``
+""""""""""""""""""""""""""""""""
+
+.. code-block:: bash
+
+        CELERYD_NODES="w1"
+
+        # Absolute or relative path to the 'celery' command:
+        CELERY_BIN="$POLICYKIT_ENV/bin/celery"
+
+        # App instance to use
+        CELERY_APP="policykit"
+
+        # How to call manage.py
+        CELERYD_MULTI="multi"
+
+        # Extra command-line arguments to the worker
+        CELERYD_OPTS="--time-limit=300 --concurrency=8"
+
+        # - %n will be replaced with the first part of the nodename.
+        # - %I will be replaced with the current child process index
+        #   and is important when using the prefork pool to avoid race conditions.
+        CELERYD_PID_FILE="/var/run/celery/%n.pid"
+        CELERYD_LOG_FILE="/var/log/celery/%n%I.log"
+        CELERYD_LOG_LEVEL="INFO"
+
+        # you may wish to add these options for Celery Beat
+        CELERYBEAT_PID_FILE="/var/run/celery/policykit_beat.pid"
+        CELERYBEAT_LOG_FILE="/var/log/celery/policykit_beat.log"
+
+
+``/etc/systemd/system/celery-policykit.service``
+""""""""""""""""""""""""""""""""""""""""""""""""
+
+.. code-block:: bash
+
+        [Unit]
+        Description=Celery Service
+        After=network.target
+
+        [Service]
+        Type=forking
+        User=celery
+        Group=celery
+        EnvironmentFile=/etc/conf.d/celery-policykit
+        WorkingDirectory=$POLICYKIT_REPO/policykit
+        ExecStart=/bin/sh -c '${CELERY_BIN} multi start ${CELERYD_NODES} \
+        -A ${CELERY_APP} --pidfile=${CELERYD_PID_FILE} \
+        --logfile=${CELERYD_LOG_FILE} --loglevel=${CELERYD_LOG_LEVEL} ${CELERYD_OPTS}'
+        ExecStop=/bin/sh -c '${CELERY_BIN} multi stopwait ${CELERYD_NODES} \
+        --pidfile=${CELERYD_PID_FILE}'
+        ExecReload=/bin/sh -c '${CELERY_BIN} multi restart ${CELERYD_NODES} \
+        -A ${CELERY_APP} --pidfile=${CELERYD_PID_FILE} \
+        --logfile=${CELERYD_LOG_FILE} --loglevel=${CELERYD_LOG_LEVEL} ${CELERYD_OPTS}'
+
+        [Install]
+        WantedBy=multi-user.target
+
+
+``/etc/systemd/system/celerybeat-policykit.service``
+""""""""""""""""""""""""""""""""""""""""""""""""""""
+
+.. code-block:: bash
+
+        [Unit]
+        Description=Celery Beat Service
+        After=network.target
+
+        [Service]
+        Type=simple
+        User=celery
+        Group=celery
+        EnvironmentFile=/etc/conf.d/celery-policykit
+        WorkingDirectory=$POLICYKIT_REPO/policykit
+        ExecStart=/bin/sh -c '${CELERY_BIN} -A ${CELERY_APP}  \
+        beat --pidfile=${CELERYBEAT_PID_FILE} \
+        --logfile=${CELERYBEAT_LOG_FILE} --loglevel=${CELERYD_LOG_LEVEL} \
+        --schedule=/var/run/celery/celerybeat-policykit-schedule'
+
+        [Install]
+        WantedBy=multi-user.target
+
 
 | After creating the files (and after any time you change them) run the following command:
 
@@ -250,25 +350,26 @@ Running PolicyKit in Production
 
  sudo service apache2 start
  sudo service rabbitmq-server start
- sudo systemctl start celery.service
- sudo systemctl start celerybeat.service
+ sudo systemctl start celery-policykit celerybeat-policykit
 
 | Verify that there are no errors with celery and celerybeat by running these commands:
 
 ::
 
- sudo systemctl status celery
- sudo systemctl status celerybeat
+ sudo systemctl status celery-policykit
+ sudo systemctl status celerybeat-policykit
 
 | Once things are up and running, you should be able to access the PolicyKit editor in the browser at ``https://<your domain>/main``.
 
 Troubleshooting
-----------------
+"""""""""""""""
 
-| If celery failed to start up as a service, try running celery directly to see if there are errors in your code:
+| If celery or celerybeat fail to start up as a service, try running celery directly to see if there are errors in your code:
 
 ::
 
- celery worker --uid <User that runs celery> -A policykit
+ celery -A policykit worker -l info --uid celery
+ celery -A policykit beat -l info --uid celery --schedule=/var/run/celery/celerybeat-policykit-schedule
+
 
 If celerybeat experiences errors starting up, check the logs at ``/var/log/celery/beat.log``.

--- a/docs/source/integrations.rst
+++ b/docs/source/integrations.rst
@@ -14,9 +14,14 @@ Slack Integration
 
 Initial Setup
 """""""""""""
+The PolicyKit server admin has to do this once:
 
-Add instructions for creating Client ID and Client Secret.
-
+1. Go to https://api.slack.com/apps, click "Create New App"
+2. Click "Event Subscriptions"->"Enable Events" and enter the request URL "https://<YOUR URL>/slack/action". Subscribe to bot events and subscribe to events on behalf of users.
+3. Click "OAuth & Permissions" and add redirect URL "https://<YOUR URL>/slack/oauth"
+4. Click "Manage Distribution"->"Activate Public Distribution"
+5. Click "Basic Information." Copy the Client ID and Client Secret into the ``private.py`` file on your PolicyKit server.
+6. To test it out, go to "https://<YOUR URL>/main" and click "Add to Slack" and then "Sign in with Slack."
 
 Reddit Integration
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/integrations.rst
+++ b/docs/source/integrations.rst
@@ -12,19 +12,42 @@ Integrations
 Slack Integration
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+Initial Setup
+"""""""""""""
+
+Add instructions for creating Client ID and Client Secret.
+
+
 Reddit Integration
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+Initial Setup
+"""""""""""""
+
+Add instructions for creating Client ID and Client Secret.
+
 Discord Integration
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Initial Setup
+"""""""""""""
+
+Add instructions for creating Client ID, Client Secret, and bot token.
 
 Discourse Integration
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 This is a connector for `Discourse <https://www.discourse.org/>`_ that lets you write policies that govern Discourse communities.
 
+Initial Setup
+"""""""""""""
+
+There is no initial setup required for Discourse. Each Discourse community that wants to install PolicyKit will need to register the auth redirect separately (see below).
+
+
 Setting up your Discourse community
 """""""""""""""""""""""""""""""""""
+
 
 You can set up a Discourse community either by running a server that hosts a community locally or by creating a community hosted remotely by `Discourse.org <https://www.discourse.org/>`_. To host a community remotely, you can press "Start Trial" `on this page <https://www.discourse.org/pricing>`_ and follow the instructions to set up a community. Discourse.org offers free 14 day trials, which can be extended by contacting support.
 
@@ -36,7 +59,7 @@ Once the site is up and running, you need to configure a few settings to enable 
  * **min user level for user api key**: `0`
  * **allowed user api auth redirects**: Add an entry: `[YOUR SERVER URL]/discourse/auth`. (example: `https://policykit.org/discourse/auth`)
 
-Installing PolicyKit to your Discourse community
+ Installing PolicyKit to your Discourse community
 """""""""""""""""""""""""""""""""""""""""""""""""""
 
 On the login page, select "Install PolicyKit to Discourse". On the Configure screen that appears, enter the full URL of your Discourse community (example: `https://policykit.trydiscourse.com`). On the next screen that appears, you must approve PolicyKit's authorization to access your Discourse community. On the third and final screen, you must select a Starter Kit system of governance, which will initialize your community with the selected system of governance.
@@ -57,11 +80,14 @@ Metagov Integration
 
 This is a special connector for `Metagov <http://docs.metagov.org/>`_ that lets you write policies that make use of the `Metagov API <https://prototype.metagov.org/redoc/>`_, which provides access to several external platforms and governance tools.
 
-In order to use this integration, you need to deploy an instance of Metagov on the same machine as PolicyKit.
-The ``METAGOV_URL`` setting must be set in your ``private.py`` file.
+Initial Setup
+"""""""""""""
 
-Configuring Metagov
-"""""""""""""""""""
+In order to use this integration, you need to deploy an instance of Metagov on the same machine as PolicyKit. See `Installing Metagov <https://docs.metagov.org/en/latest/installation.html>`_ for instructions.
+To enable Metagov in PolicyKit, set ``METAGOV_URL`` in your ``private.py`` file to point to your Metagov server.
+
+Configuring Metagov for a Community
+"""""""""""""""""""""""""""""""""""
 
 Configure Metagov by navigating to "Settings" in the PolicyKit web interface.
 At this time, only community admins are permitted to view and edit the Metagov configuration.
@@ -151,11 +177,11 @@ Use the ``metagov`` client to perform asynchronous governance processes. Here's 
 
     import datetime
 
-    closing_at = action.proposal.proposal_time + datetime.timedelta(days=3)
+    closing_at = (action.proposal.proposal_time + datetime.timedelta(days=3)).strftime("%Y-%m-%d")
     result = metagov.start_process("loomio.poll", {
         "title": "Agree or disagree?",
         "options": ["agree", "disagree"],
-        "closing_at": closing_at.strftime("%Y-%m-%d")
+        "closing_at": closing_at
     })
     poll_url = result.get('poll_url')
     # elided: send the poll URL to users and let them know to vote

--- a/policykit/integrations/metagov/templates/metagov_config.html
+++ b/policykit/integrations/metagov/templates/metagov_config.html
@@ -20,6 +20,6 @@
 {% elif metagov_enabled %}
   <div>Metagov is enabled for this community, but you do not have access to view the configuration.</div>
 {% else %}
-  <div>Metagov not enabled for this community.</div>
+  <div>Metagov is not enabled for this community.</div>
 {% endif %}
 


### PR DESCRIPTION
When PolicyKit and Metagov are deployed together, some extra steps need to be taken to ensure that the two celery daemons don't conflict. PolicyKit and Metagov each have their own celery and celerybeat daemons the use separate [RabbitMQ virtual hosts](https://www.rabbitmq.com/vhosts.html) as brokers.

I also updated the structure of the Apache2 and Celery setup instructions to be very similar to the metagov equivalents (https://docs.metagov.org/en/latest/installation.html#set-up-celery) so the setup process should be smoother for folks that are installing both at the same time.

This update also includes instructions for creating a dedicated ``celery`` user to run the worker, instead of running with a superuser which [is dangerous](https://docs.celeryproject.org/en/stable/userguide/daemonizing.html#running-the-worker-with-superuser-privileges-root).