### PR TITLE
Use callbacks to get updates from Metagov GovernanceProcesses

### DIFF
--- a/docs/source/sample_policies.rst
+++ b/docs/source/sample_policies.rst
@@ -176,12 +176,15 @@ to decide whether to accept or reject the proposal. If rejected, delete the topi
     discourse_username = action.initiator.metagovuser.external_username
     topic_url = action.event_data["url"]
 
+    import datetime
+    closing_at = (action.proposal.proposal_time + datetime.timedelta(days=3)).strftime("%Y-%m-%d")
+
     # Kick off a vote in Loomio
     parameters = {
         "title": f"Vote on adding proposal '{title}'",
         "details": f"proposed by {discourse_username} on Discourse: {topic_url}",
         "options": ["agree", "disagree"],
-        "closing_at": "2022-01-01"
+        "closing_at": closing_at
     }
     result = metagov.start_process("loomio.poll", parameters)
     poll_url = result.outcome.get("poll_url")

--- a/policykit/integrations/metagov/models.py
+++ b/policykit/integrations/metagov/models.py
@@ -37,26 +37,12 @@ class MetagovProcess(models.Model):
     def data(self) -> MetagovProcessData:
         """
         A ``MetagovProcessData`` object with ``status`, ``errors``, and ``outcome``.
-        This is the most recently fetched data, but it is not necessarily up-to-date with Metagov.
-        Use ``refresh_from_metagov`` to get latest data.
+        This is the most recent data that we've received from Metagov at the Callback URL (post_outcome view).
         """
         if self.json_data:
             data = json.loads(self.json_data)
             return MetagovProcessData(data)
         return None
-
-    def refresh_from_metagov(self):
-        """
-        Fetch latest process data from Metagov and store it.
-        Policies can access latest data object at ``data``.
-        """
-        logger.info(f"Making request to get process at '{self.location}'")
-        response = requests.get(self.location)
-        if not response.ok:
-            raise Exception(f"Error getting process: {response.status_code} {response.reason} {response.text}")
-        logger.info(response.text)
-        self.json_data = response.text
-        self.save()
 
     def close(self):
         if self.data.status == "completed":

--- a/policykit/integrations/metagov/views.py
+++ b/policykit/integrations/metagov/views.py
@@ -53,11 +53,6 @@ def post_outcome(request, id):
         return HttpResponseBadRequest("unable to decode body")
 
     logger.info(f"Received external process outcome: {body}")
-    if body.get("status") != "completed":
-        return HttpResponseBadRequest("process not completed")
-    if not body.get("outcome") and not body.get("errors"):
-        return HttpResponseBadRequest("completed process must have either outcome or errors")
-
     process.json_data = json.dumps(body)
     process.save()
     return HttpResponse()

--- a/policykit/policykit/celery.py
+++ b/policykit/policykit/celery.py
@@ -8,8 +8,6 @@ from celery import Celery
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'policykit.settings')
 
 app = Celery('policykit',
-             broker='amqp://',
-             backend='amqp://',
              include=['policyengine.tasks',
                       'integrations.reddit.tasks',
                       'integrations.discourse.tasks'])

--- a/policykit/policykit/settings.py
+++ b/policykit/policykit/settings.py
@@ -239,6 +239,7 @@ LOGGING = {
 
 from celery.schedules import crontab
 
+# Replace with "amqp://USERNAME:PASSWORD@localhost:5672/VIRTUALHOST"
 CELERY_BROKER_URL = 'amqp://'
 CELERY_RESULT_BACKEND = 'django-db'
 CELERY_CACHE_BACKEND = 'django-cache'


### PR DESCRIPTION
#### old behavior
PolicyKit would need to fetch the latest `outcome` of an ongoing Metagov process by hitting the `GET /process` endpoint

#### new behavior
PolicyKit receives a callback from metagov each time the `outcome` is changed. The callback is received by the `post_outcome` view in `integrations.metagov.views`. It updates the data in the `MetagovProcess` record.

This is change was made possible by https://github.com/metagov/metagov-prototype/pull/42. More context in https://github.com/metagov/metagov-prototype/issues/19.