### PR TITLE
Update logging format and settings

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -18,6 +18,7 @@ import sphinx_rtd_theme
 policykit_path = os.path.abspath('../../policykit')
 sys.path.insert(0, policykit_path)
 
+os.environ.setdefault('POLICYKIT_LOG_FILE', policykit_path + '/docs.log')
 os.environ.setdefault('PRIVATE_FILE_PATH', policykit_path + '/private_template.py')
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'policykit.settings')
 

--- a/docs/source/gettingstarted.rst
+++ b/docs/source/gettingstarted.rst
@@ -30,7 +30,7 @@ Getting Started
 
  cp private_template.py private.py
 
-| PolicyKit requires a directory to send logs to. By default, it logs to the path ``debug.log``. Edit the ``LOGGING_ROOT_DIR`` variable in ``settings.py`` to point to the right logging directory (for example ``/var/log/django``).
+| PolicyKit requires a file to log to. By default, it logs to the file ``/var/log/django/debug.log``. To change this, set the ``POLICYKIT_LOG_FILE`` environment variable or edit the ``LOGGING`` object in ``settings.py`` directly.
 
 | To verify that you have set the PolicyKit server up correctly, run the following command:
 
@@ -81,8 +81,6 @@ Running PolicyKit in Production
    - Update the ``ALLOWED_HOSTS`` field to point to your host.
 
    - Update that the database path under ``DATABASES``. Recommended: set the database path to ``/var/databases/policykit/db.sqlite3``. Make sure the directory exists.
-
-   - Update the ``LOGGING_ROOT_DIR`` to point to your log directory (recommended: ``/var/log/django``).
 
    - Set ``DEBUG`` to False
 

--- a/policykit/integrations/discord/views.py
+++ b/policykit/integrations/discord/views.py
@@ -18,7 +18,7 @@ import time
 
 logger = logging.getLogger(__name__)
 
-websocket.enableTrace(True)
+websocket.enableTrace(False)
 
 # Used for Boolean voting
 EMOJI_LIKE = '%F0%9F%91%8D'
@@ -62,7 +62,7 @@ def on_open(wsapp):
 
 def should_create_action(message, type=None):
     if type == None:
-        logger.error('[discord] type parameter not specified in should_create_action')
+        logger.error('type parameter not specified in should_create_action')
         return False
 
     created_at = None
@@ -78,7 +78,7 @@ def should_create_action(message, type=None):
         created_at = datetime.datetime.strptime(created_at, "%Y-%m-%dT%H:%M:%S.%f+00:00")
 
     if created_at == None:
-        logger.error("[discord] created_at is None when it shouldn't be in should_create_action")
+        logger.error("created_at is None when it shouldn't be in should_create_action")
         return False
 
     now = datetime.datetime.now()
@@ -109,7 +109,7 @@ def handle_guild_create_event(data):
                 channel_id=channel['id'],
                 channel_name=channel['name']
             )
-    logger.info(f'[discord] Populated DiscordChannel objects from GUILD_CREATE event')
+    logger.info(f'Populated DiscordChannel objects from GUILD_CREATE event')
 
 def handle_message_create_event(data):
     if should_create_action(data, type="MESSAGE_CREATE"):
@@ -129,7 +129,7 @@ def handle_message_create_event(data):
         )
         action.initiator = u
 
-        logger.info(f'[discord] New message in channel {channel.channel_name}: {data["content"]}')
+        logger.info(f'New message in channel {channel.channel_name}: {data["content"]}')
 
         return action
 
@@ -152,7 +152,7 @@ def handle_message_delete_event(data):
     )
     action.initiator = u
 
-    logger.info(f'[discord] Message deleted in channel {channel.channel_name}: {message["content"]}')
+    logger.info(f'Message deleted in channel {channel.channel_name}: {message["content"]}')
 
     return action
 
@@ -177,7 +177,7 @@ def handle_channel_update_event(data):
     action.initiator = u
 
     channel = DiscordChannel.objects.filter(channel_id=data['id'])[0]
-    logger.info(f'[discord] Channel {channel.channel_name} renamed to {action.name}')
+    logger.info(f'Channel {channel.channel_name} renamed to {action.name}')
 
     # Update DiscordChannel object
     channel.channel_name = action.name
@@ -208,7 +208,7 @@ def handle_channel_create_event(data):
     )
     action.initiator = u
 
-    logger.info(f'[discord] Channel created: {action.name}')
+    logger.info(f'Channel created: {action.name}')
 
     return action
 
@@ -227,7 +227,7 @@ def handle_channel_delete_event(data):
     )
     action.initiator = u
 
-    logger.info(f'[discord] Channel deleted: {data["name"]}')
+    logger.info(f'Channel deleted: {data["name"]}')
 
     return action
 
@@ -287,13 +287,13 @@ def on_message(wsapp, message):
     payload = json.loads(message)
     op = payload['op']
     if op == 0: # Opcode 0 Dispatch
-        logger.info(f'[discord] Received event named {payload["t"]}')
+        logger.info(f'Received event named {payload["t"]}')
         sequence_number = payload['s']
         handle_event(payload['t'], payload['d'])
     elif op == 10: # Opcode 10 Hello
         # Receive heartbeat interval
         heartbeat_interval = payload['d']['heartbeat_interval']
-        logger.info(f'[discord] Received heartbeat of {heartbeat_interval} ms from the Discord gateway')
+        logger.info(f'Received heartbeat of {heartbeat_interval} ms from the Discord gateway')
 
         # Send an Opcode 2 Identify
         payload = json.dumps({
@@ -310,15 +310,15 @@ def on_message(wsapp, message):
             }
         })
         wsapp.send(payload)
-        logger.info('[discord] Sent an Opcode 2 Identify to the Discord gateway')
+        logger.info('Sent an Opcode 2 Identify to the Discord gateway')
     elif op == 11: # Opcode 11 Heartbeat ACK
         ack_received = True
 
 def on_error(wsapp, error):
-    logger.error(f'[discord] Websocket error: {error}')
+    logger.error(f'Websocket error: {error}')
 
 def on_close(wsapp, code, reason):
-    logger.error(f'[discord] Connection to Discord gateway closed with error code {code}')
+    logger.error(f'Connection to Discord gateway closed with error code {code}')
 
 # Open gateway connection
 def connect_gateway():

--- a/policykit/integrations/discourse/tasks.py
+++ b/policykit/integrations/discourse/tasks.py
@@ -46,27 +46,27 @@ def discourse_listener_actions():
         req = urllib.request.Request(url + '/latest.json')
         req.add_header("User-Api-Key", api_key)
         resp = urllib.request.urlopen(req)
-        logger.info(f"[celery-discourse] topics response: {resp.status} {resp.reason}")
+        logger.info(f"topics response: {resp.status} {resp.reason}")
         res = json.loads(resp.read().decode('utf-8'))
         topics = res['topic_list']['topics']
         users = res['users']
-        logger.info(f"[celery-discourse] {len(topics)} topics")
+        logger.info(f"{len(topics)} topics")
         for topic in topics:
             user_id = topic['posters'][0]['user_id']
             usernames = [u['username'] for u in users if u['id'] == user_id]
             if not usernames:
-                logger.error(f"[celery-discourse] no username found for user id {user_id}, skipping topic")
+                logger.error(f"no username found for user id {user_id}, skipping topic")
                 continue
             username = usernames[0]
             call_type = '/posts.json'
             if should_create_action(community, call_type, topic, username):
-                logger.info(f"[celery-discourse] creating new DiscourseCreateTopic object for topic {topic['title']}")
+                logger.info(f"creating new DiscourseCreateTopic object for topic {topic['title']}")
 
                 # Retrieve raw from first post under topic (created when topic created)
                 req = urllib.request.Request(f"{url}/t/{str(topic['id'])}/posts.json?include_raw=True")
                 req.add_header("User-Api-Key", api_key)
                 resp = urllib.request.urlopen(req)
-                logger.info(f"[celery-discourse] raw post response: {resp.status} {resp.reason}")
+                logger.info(f"raw post response: {resp.status} {resp.reason}")
                 res = json.loads(resp.read().decode('utf-8'))
                 raw = res['post_stream']['posts'][0]['raw']
 
@@ -83,7 +83,7 @@ def discourse_listener_actions():
                 )
                 new_api_action.initiator = u
                 actions.append(new_api_action)
-        logger.info(f"[celery-discourse] {len(actions)} actions created")
+        logger.info(f"{len(actions)} actions created")
         for action in actions:
             action.community_origin = True
             action.is_bundled = False

--- a/policykit/integrations/metagov/views.py
+++ b/policykit/integrations/metagov/views.py
@@ -8,7 +8,7 @@ from django.contrib.auth.decorators import login_required
 from django.contrib.auth.models import ContentType, Permission
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import PermissionDenied
-from django.http import HttpResponse, HttpResponseBadRequest, HttpResponseServerError
+from django.http import HttpResponse, HttpResponseBadRequest, HttpResponseServerError, HttpResponseNotFound
 from django.shortcuts import render
 from django.views.decorators.csrf import csrf_exempt
 from integrations.metagov.library import metagov_slug, update_metagov_community

--- a/policykit/policyengine/tasks.py
+++ b/policykit/policyengine/tasks.py
@@ -14,7 +14,7 @@ from datetime import datetime, timedelta
 @shared_task
 def consider_proposed_actions():
     platform_actions = PlatformAction.objects.filter(proposal__status=Proposal.PROPOSED, is_bundled=False)
-    logger.info(f"[celery] {platform_actions.count()} proposed PlatformActions")
+    logger.info(f"{platform_actions.count()} proposed PlatformActions")
     for action in platform_actions:
          #if they have execute permission, skip all policies
         if action.initiator.has_perm(action.app_name + '.can_execute_' + action.action_codename):
@@ -37,7 +37,7 @@ def consider_proposed_actions():
                 execute_policy(policy, action)"""
 
     constitution_actions = ConstitutionAction.objects.filter(proposal__status=Proposal.PROPOSED, is_bundled=False)
-    logger.info(f"[celery] {constitution_actions.count()} proposed ConstitutionActions")
+    logger.info(f"{constitution_actions.count()} proposed ConstitutionActions")
     for action in constitution_actions:
         #if they have execute permission, skip all policies
         if action.initiator.has_perm(action.app_name + '.can_execute_' + action.action_codename):
@@ -50,11 +50,11 @@ def consider_proposed_actions():
                     break
 
     clean_up_logs()
-    logger.info('[celery] finished task')
+    logger.info('finished task')
 
 
 def clean_up_logs():
     hours_ago = timezone.now()-timezone.timedelta(hours=DB_LOG_EXPIRATION_HOURS)
     count,_ = EvaluationLog.objects.filter(create_datetime__lt=hours_ago).delete()
     if count:
-        logger.info(f"[celery] Deleted {count} EvaluationLogs")
+        logger.info(f"Deleted {count} EvaluationLogs")

--- a/policykit/policyengine/views.py
+++ b/policykit/policyengine/views.py
@@ -95,7 +95,7 @@ def v2(request):
         }
 
     action_log_data = []
-    logger.info(f'[policyengine] Number of action objects: {Action.objects.all().count()}')
+    logger.info(f'Number of action objects: {Action.objects.all().count()}')
     for action in Action.objects.filter(data__community_id=user.community.id):
         action_data = {
             'actor': action.actor,


### PR DESCRIPTION
1. Update logging format to match metagov. This includes a timestamp and where the log is coming from:

        ```
        2021-05-11 22:29:18,718 policyengine.views INFO     0 proposed PlatformActions
        2021-05-11 22:29:18,725 policyengine.views INFO     0 proposed ConstitutionActions
        2021-05-11 22:29:18,832 integrations.discourse.tasks INFO     topics response: 200 OK
        2021-05-11 22:29:18,833 integrations.discourse.tasks INFO     30 topics
        2021-05-11 22:29:18,848 integrations.discourse.tasks INFO     0 actions created
        2021-05-11 22:30:18,730 policyengine.views INFO     0 proposed PlatformActions
        2021-05-11 22:30:18,732 policyengine.views INFO     0 proposed ConstitutionActions
        2021-05-11 22:30:18,870 integrations.discourse.tasks INFO     topics response: 200 OK
        2021-05-11 22:30:18,871 integrations.discourse.tasks INFO     30 topics
        2021-05-11 22:30:18,887 integrations.discourse.tasks INFO     0 actions created
        ```
2. Change the way we define the logging path. Change the default path back to `/var/log/django/debug.log`. Sorry for the back-and-forth on this from https://github.com/amyxzhang/policykit/pull/357.. I found another way to resolve the sphinx issue by setting an envvar in the `conf.py`.
3. For all integrations and policyengine, log to file and console by default.