### PR TITLE
Security fixes in Metagov integration, and other improvements in metagov integration

### DIFF
--- a/docs/source/gettingstarted.rst
+++ b/docs/source/gettingstarted.rst
@@ -149,6 +149,11 @@ Make sure you have a domain dedicated to Policykit that is pointing to your serv
                                 </Files>
                         </Directory>
 
+                        # 🚨 IMPORTANT if using Metagov: Restrict internal endpoints to local traffic 🚨
+                        <Location /metagov/internal>
+                                Require local
+                        </Location>
+
                         WSGIDaemonProcess policykit python-home=$POLICYKIT_ENV python-path=$POLICYKIT_REPO/policykit
                         WSGIProcessGroup policykit
                         WSGIScriptAlias / $POLICYKIT_REPO/policykit/policykit/wsgi.py

--- a/docs/source/integrations.rst
+++ b/docs/source/integrations.rst
@@ -112,7 +112,7 @@ To use Metagov with PolicyKit, the server admin needs to do this once:
 1. Deploy an instance of Metagov on the same machine as PolicyKit. See `Installing Metagov <https://docs.metagov.org/en/latest/installation.html>`_ for instructions.
 2. In the ``.env`` file in PolicyKit, set the URL for receiving events: ``DRIVER_EVENT_RECEIVER_URL=[POLICYKIT_URL]/metagov/internal/action``
 3. To enable Metagov in PolicyKit, set the ``METAGOV_URL`` in your ``private.py`` file to point to your Metagov instance.
-4. Ensure that the ``/metagov/action`` route is restricted to local traffic. Follow the Apache2 example in :doc:`Getting Started <../gettingstarted>`.
+4. Ensure that ``/metagov/internal`` is restricted to local traffic. Follow the Apache2 example in :doc:`Getting Started <../gettingstarted>`.
 
 
 Configuring Metagov

--- a/docs/source/integrations.rst
+++ b/docs/source/integrations.rst
@@ -107,8 +107,13 @@ This is a special connector for `Metagov <http://docs.metagov.org/>`_ that lets 
 Initial Setup
 """""""""""""
 
-In order to use this integration, you need to deploy an instance of Metagov on the same machine as PolicyKit. See `Installing Metagov <https://docs.metagov.org/en/latest/installation.html>`_ for instructions.
-To enable Metagov in PolicyKit, set ``METAGOV_URL`` in your ``private.py`` file to point to your Metagov server.
+To use Metagov with PolicyKit, the server admin needs to do this once:
+
+1. Deploy an instance of Metagov on the same machine as PolicyKit. See `Installing Metagov <https://docs.metagov.org/en/latest/installation.html>`_ for instructions.
+2. In the ``.env`` file in PolicyKit, set the URL for receiving events: ``DRIVER_EVENT_RECEIVER_URL=[POLICYKIT_URL]/metagov/internal/action``
+3. To enable Metagov in PolicyKit, set the ``METAGOV_URL`` in your ``private.py`` file to point to your Metagov instance.
+4. Ensure that the ``/metagov/action`` route is restricted to local traffic. Follow the Apache2 example in :doc:`Getting Started <../gettingstarted>`.
+
 
 Configuring Metagov
 """""""""""""""""""

--- a/policykit/django_db_logger/urls.py
+++ b/policykit/django_db_logger/urls.py
@@ -4,4 +4,4 @@ from django_db_logger.views import LogListView
 
 app_name = 'django_db_logger'
 
-urlpatterns = [path("", login_required(login_url="/login")(LogListView.as_view()))]
+urlpatterns = [path("", login_required(login_url="/login")(LogListView.as_view()), name="logs")]

--- a/policykit/django_db_logger/urls.py
+++ b/policykit/django_db_logger/urls.py
@@ -2,4 +2,6 @@ from django.urls import path
 from django.contrib.auth.decorators import login_required
 from django_db_logger.views import LogListView
 
+app_name = 'django_db_logger'
+
 urlpatterns = [path("", login_required(login_url="/login")(LogListView.as_view()))]

--- a/policykit/integrations/metagov/library.py
+++ b/policykit/integrations/metagov/library.py
@@ -80,7 +80,7 @@ class Metagov:
         logger.info(payload)
 
         url = f"{settings.METAGOV_URL}/api/internal/process/{process_name}"
-        payload["callback_url"] = f"{settings.SERVER_URL}/metagov/outcome/{model.pk}"
+        payload["callback_url"] = f"{settings.SERVER_URL}/metagov/internal/outcome/{model.pk}"
 
         # Kick off process in Metagov
         response = requests.post(url, json=payload, headers=self.headers)

--- a/policykit/integrations/metagov/templates/metagov_config_script.html
+++ b/policykit/integrations/metagov/templates/metagov_config_script.html
@@ -69,7 +69,9 @@
                   })
                 } else {
                   response.json().then(data => {
-                    $('#alerts').html("<b>Configuration saved!</b>");
+                    $('#alerts').css("color", "").html("<b>Configuration saved!</b>");
+                    var config_str = JSON.stringify(data.config, null, 2);
+                    $('#alerts').append(`<pre>${config_str}</pre>`);
                     if (data.hooks.length > 0) {
                       data.hooks.sort()
                       const $ul = $('<ul>').append(
@@ -77,7 +79,7 @@
                           $("<li>").append($("<code>").text(url))
                         )
                       );
-                      $('#alerts').append("<div>These are your community webhook receivers that can be registered with external platforms:</div>");
+                      $('#alerts').append("<b>Community webhook receivers to register with external platforms:</b>");
                       $('#alerts').append($ul);
                     }
                   })

--- a/policykit/integrations/metagov/urls.py
+++ b/policykit/integrations/metagov/urls.py
@@ -4,7 +4,7 @@ from integrations.metagov import views
 
 
 urlpatterns = [
-    path("outcome/<int:id>", views.post_outcome),
+    path("internal/outcome/<int:id>", views.post_outcome),
+    path("internal/action", views.action),
     path("save_config", views.save_config),
-    path("action", views.action),
 ]

--- a/policykit/integrations/metagov/urls.py
+++ b/policykit/integrations/metagov/urls.py
@@ -4,7 +4,7 @@ from integrations.metagov import views
 
 
 urlpatterns = [
-    path("internal/outcome/<int:id>", views.post_outcome),
-    path("internal/action", views.action),
+    path("internal/outcome/<int:id>", views.internal_receive_outcome),
+    path("internal/action", views.internal_receive_action),
     path("save_config", views.save_config),
 ]

--- a/policykit/integrations/metagov/views.py
+++ b/policykit/integrations/metagov/views.py
@@ -1,14 +1,11 @@
 import json
 import logging
 
-import requests
-from django.conf import settings
 from django.contrib.auth import get_user
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.models import ContentType, Permission
 from django.contrib.contenttypes.models import ContentType
 from django.http import JsonResponse, HttpResponse, HttpResponseBadRequest, HttpResponseServerError, HttpResponseNotFound
-from django.shortcuts import render
 from django.views.decorators.csrf import csrf_exempt
 from integrations.metagov.library import metagov_slug, update_metagov_community, get_webhooks
 from integrations.metagov.models import MetagovProcess, MetagovPlatformAction, MetagovUser
@@ -18,6 +15,7 @@ logger = logging.getLogger(__name__)
 
 
 @login_required(login_url='/login')
+@csrf_exempt
 def save_config(request):
     user = get_user(request)
     community = user.community
@@ -37,8 +35,9 @@ def save_config(request):
     return JsonResponse({"hooks": hooks, "config": community_config})
 
 
+# INTERNAL ENDPOINT, no auth
 @csrf_exempt
-def post_outcome(request, id):
+def internal_receive_outcome(request, id):
     if request.method != "POST" or not request.body:
         return HttpResponseBadRequest()
     try:
@@ -56,9 +55,9 @@ def post_outcome(request, id):
     process.save()
     return HttpResponse()
 
-
+# INTERNAL ENDPOINT, no auth
 @csrf_exempt
-def action(request):
+def internal_receive_action(request):
     """
     Receive event from Metagov, and create a new MetagovPlatformAction.
 

--- a/policykit/policyengine/views.py
+++ b/policykit/policyengine/views.py
@@ -1,15 +1,12 @@
 from django.contrib.auth import get_user
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.models import Permission
-from django.contrib.contenttypes.models import ContentType
-from django.http import HttpResponseRedirect, HttpResponse, JsonResponse, HttpResponseBadRequest, HttpResponseNotFound
+from django.http import HttpResponse, JsonResponse, HttpResponseBadRequest
 from django.views.decorators.csrf import csrf_exempt
 from django.shortcuts import render, redirect
-from actstream import action
-from actstream.models import model_stream, target_stream, Action
+from actstream.models import Action
 from policyengine.filter import *
 from policykit.settings import SERVER_URL, METAGOV_ENABLED
-import urllib.request
 import urllib.parse
 import logging
 import json
@@ -29,7 +26,7 @@ def v2(request):
     from policyengine.models import Community, CommunityUser, CommunityRole, CommunityDoc, PlatformPolicy, ConstitutionPolicy
 
     user = get_user(request)
-
+    user.community = user.community
     users = CommunityUser.objects.filter(community=user.community)
     roles = user.community.get_roles()
     docs = user.community.get_documents()

--- a/policykit/policykit/urls.py
+++ b/policykit/policykit/urls.py
@@ -18,7 +18,7 @@ urlpatterns = [
             'discord_client_id': DISCORD_CLIENT_ID
         }
     )),
-    path('logout/', policyviews.logout),
+    path('logout/', policyviews.logout, name="logout"),
     path('main/', policyviews.v2),
     path('main/editor/', policyviews.editor),
     path('main/selectrole/', policyviews.selectrole),
@@ -29,8 +29,8 @@ urlpatterns = [
     path('main/selectdocument/', policyviews.selectdocument),
     path('main/actions/', policyviews.actions),
     path('main/policyengine/', include('policyengine.urls')),
-    path('main/settings/', policyviews.settings_page),
-    path('logs/', include('django_db_logger.urls')),
+    path('main/settings/', policyviews.settings_page, name="settings"),
+    path('main/logs/', include('django_db_logger.urls', namespace='django_db_logger')),
     path('admin/', admin.site.urls),
     path('slack/', include('integrations.slack.urls')),
     path('reddit/', include('integrations.reddit.urls')),

--- a/policykit/policykit/urls.py
+++ b/policykit/policykit/urls.py
@@ -1,12 +1,14 @@
+import urllib.parse
+
+from django.conf.urls import include, url
 from django.contrib import admin
 from django.contrib.auth import views
 from django.urls import path
-from django.conf.urls import include, url
-from django.views.generic import TemplateView
-from django.shortcuts import redirect
-import urllib.parse
-from policykit.settings import SERVER_URL, SLACK_CLIENT_ID, REDDIT_CLIENT_ID, DISCORD_CLIENT_ID
 from policyengine import views as policyviews
+
+from policykit.settings import (DISCORD_CLIENT_ID, METAGOV_ENABLED,
+                                REDDIT_CLIENT_ID, SERVER_URL, SLACK_CLIENT_ID)
+
 
 urlpatterns = [
     path('login/', views.LoginView.as_view(
@@ -36,7 +38,9 @@ urlpatterns = [
     path('reddit/', include('integrations.reddit.urls')),
     path('discord/', include('integrations.discord.urls')),
     path('discourse/', include('integrations.discourse.urls')),
-    path('metagov/', include('integrations.metagov.urls')),
     url(r'^$', policyviews.homepage),
     url('^activity/', include('actstream.urls'))
 ]
+
+if METAGOV_ENABLED:
+    urlpatterns += [path('metagov/', include('integrations.metagov.urls'))]

--- a/policykit/templates/policyadmin/dashboard/dashboard_base.html
+++ b/policykit/templates/policyadmin/dashboard/dashboard_base.html
@@ -132,6 +132,12 @@
     .profileDropdownElement:hover {
       color: #808b96;
     }
+    .profileDropdownElement h4 a {
+      color: inherit;
+    }
+    .profileDropdownElement:hover a {
+      text-decoration: none;
+    }
 
   </style>
 
@@ -157,14 +163,17 @@
         {% endif %}
       </div>
       <div class="profileDropdown">
-        <div class="profileDropdownElement" id="settings">
-          <h4>Settings</h4>
+        <div class="profileDropdownElement">
+          <h4><a href="{% url 'settings' %}">Settings</a></h4>
         </div>
         <div class="profileDropdownElement">
-          <h4>Help</h4>
+          <h4><a href="https://policykit.readthedocs.io/" target="_blank">Help</a></h4>
         </div>
-        <div class="profileDropdownElement" id="logout">
-          <h4>Log Out</h4>
+        <div class="profileDropdownElement">
+          <h4><a href="{% url 'django_db_logger:logs' %}">Logs</a></h4>
+        </div>
+        <div class="profileDropdownElement">
+          <h4><a href="{% url 'logout' %}">Log Out</a></h4>
         </div>
       </div>
     </div>
@@ -177,8 +186,6 @@
     document.getElementById("brand").addEventListener("click", navHome);
     document.getElementById("profile").addEventListener("mouseover", showDropdown);
     document.getElementById("profile").addEventListener("mouseout", hideDropdown);
-    document.getElementById("logout").addEventListener("click", logout);
-    document.getElementById("settings").addEventListener("click", settings);
 
     function navHome() {
       window.location.href = "{{server_url}}/main/"
@@ -196,14 +203,6 @@
       for (let i = 0; i < dropdownElements.length; i++) {
         dropdownElements[i].style.display = "none"
       }
-    }
-
-    function logout() {
-      window.location.href = "{{server_url}}/logout/"
-    }
-
-    function settings() {
-      window.location.href = "{{server_url}}/main/settings/"
     }
   </script>
 

--- a/policykit/templates/policyadmin/dashboard/logs.html
+++ b/policykit/templates/policyadmin/dashboard/logs.html
@@ -1,5 +1,7 @@
+{% extends "./dashboard_base.html" %}
 {% load render_table from django_tables2 %}
 
+{% block content %}
 <!doctype html>
 <html>
     <head>
@@ -11,3 +13,4 @@
         {% render_table table %}
     </body>
 </html>
+{% endblock %}

--- a/policykit/templates/policyadmin/dashboard/settings.html
+++ b/policykit/templates/policyadmin/dashboard/settings.html
@@ -24,6 +24,9 @@
   form .help-block {
     font-style: italic;
   }
+  legend {
+    text-transform: uppercase;
+  }
   /*https://github.com/jsonform/jsonform/blob/f30484e3300cfb4bb4f7efefdde736798103e46d/lib/jsonform.js#L862*/
   .glyphicon-minus-sign:before {
     content: "\2212";

--- a/policykit/tests/test_policy_evaluation.py
+++ b/policykit/tests/test_policy_evaluation.py
@@ -230,7 +230,7 @@ and action.event_type == 'discourse.post_created'"""
 
         # 2) Mimick an incoming notification from Metagov that the action has occurred
         client = Client()
-        response = client.post(f"/metagov/action", data=event_payload, content_type="application/json")
+        response = client.post(f"/metagov/internal/action", data=event_payload, content_type="application/json")
 
         self.assertEqual(response.status_code, 200)
 


### PR DESCRIPTION
1. Add instructions to restrict access to `/metagov/internal` endpoints to local traffic only. These are the endpoints where PolicyKit receives webhook events from Metagov.
2. Add "logs" page to dropdown. Make "help" link to the readthedocs page. Make the logs page
![Screen Shot 2021-05-14 at 16 03 51](https://user-images.githubusercontent.com/5333982/118323034-09772d00-b4ce-11eb-99bf-410c3cebf58a.png)
3. Make the "logs" page inherit from the admin dashboard template:
![Screen Shot 2021-05-14 at 16 05 23](https://user-images.githubusercontent.com/5333982/118323174-3b888f00-b4ce-11eb-8f96-78cebbb7cacd.png)
4. A few bug fixes in the Metagov config editor, and make it display the submitted config on screen:
![Screen Shot 2021-05-14 at 16 06 19](https://user-images.githubusercontent.com/5333982/118323300-64108900-b4ce-11eb-9ca7-9fbdc0a86bb6.png)

