### PR TITLE
Remove remaining calls to pass_action from execute functions

### DIFF
--- a/policykit/integrations/discord/models.py
+++ b/policykit/integrations/discord/models.py
@@ -127,8 +127,6 @@ class DiscordPostMessage(PlatformAction):
             self.community_post = self.message_id
             self.save()
 
-        super().pass_action()
-
 class DiscordDeleteMessage(PlatformAction):
     channel_id = models.IntegerField()
     message_id = models.IntegerField()
@@ -159,8 +157,6 @@ class DiscordDeleteMessage(PlatformAction):
 
             # Deletes the message
             self.community.make_call(f"channels/{self.channel_id}/messages/{self.message_id}", method='DELETE')
-
-        super().pass_action()
 
 class DiscordRenameChannel(PlatformAction):
     channel_id = models.IntegerField()
@@ -202,8 +198,6 @@ class DiscordRenameChannel(PlatformAction):
             c['channel_name'] = self.name
             c.save()
 
-        super().pass_action()
-
 class DiscordCreateChannel(PlatformAction):
     guild_id = models.IntegerField()
     channel_id = models.IntegerField(blank=True)
@@ -237,8 +231,6 @@ class DiscordCreateChannel(PlatformAction):
                 channel_name=channel['name']
             )
 
-        super().pass_action()
-
 class DiscordDeleteChannel(PlatformAction):
     channel_id = models.IntegerField()
 
@@ -258,8 +250,6 @@ class DiscordDeleteChannel(PlatformAction):
         # Execute action if it didn't originate in the community
         if not self.community_origin:
             self.community.make_call(f"channels/{self.channel_id}", method='DELETE')
-
-        super().pass_action()
 
 class DiscordStarterKit(StarterKit):
     def init_kit(self, community, creator_token=None):

--- a/policykit/integrations/discourse/models.py
+++ b/policykit/integrations/discourse/models.py
@@ -165,8 +165,6 @@ class DiscourseCreateTopic(PlatformAction):
             self.community.make_call(f"/t/{self.topic_id}/recover", method='PUT')
             self.community_revert = False
 
-        super().pass_action()
-
 class DiscourseCreatePost(PlatformAction):
     raw = models.TextField()
     post_id = models.IntegerField()
@@ -194,7 +192,6 @@ class DiscourseCreatePost(PlatformAction):
             reply = self.community.make_call('/posts.json', {'raw': self.raw}) #FIXME this needs to have topic_id
             self.post_id = reply['id']
             self.save()
-        super().pass_action()
 
 class DiscourseStarterKit(StarterKit):
     def init_kit(self, community, creator_token=None):

--- a/policykit/policyengine/models.py
+++ b/policykit/policyengine/models.py
@@ -563,7 +563,6 @@ class ConstitutionActionBundle(BaseAction):
         if self.bundle_type == ConstitutionActionBundle.BUNDLE:
             for action in self.bundled_actions.all():
                 action.execute()
-                action.pass_action()
 
     def pass_action(self):
         proposal = self.proposal
@@ -608,7 +607,6 @@ class PolicykitAddCommunityDoc(ConstitutionAction):
         doc, _ = CommunityDoc.objects.get_or_create(name=self.name, text=self.text)
         doc.community = self.community
         doc.save()
-        self.pass_action()
 
     class Meta:
         permissions = (
@@ -629,7 +627,6 @@ class PolicykitChangeCommunityDoc(ConstitutionAction):
         self.doc.name = self.name
         self.doc.text = self.text
         self.doc.save()
-        self.pass_action()
 
     class Meta:
         permissions = (
@@ -649,7 +646,6 @@ class PolicykitDeleteCommunityDoc(ConstitutionAction):
     def execute(self):
         self.doc.is_active = False
         self.doc.save()
-        self.pass_action()
 
     class Meta:
         permissions = (
@@ -669,7 +665,6 @@ class PolicykitRecoverCommunityDoc(ConstitutionAction):
     def execute(self):
         self.doc.is_active = True
         self.doc.save()
-        self.pass_action()
 
     class Meta:
         permissions = (
@@ -700,7 +695,6 @@ class PolicykitAddRole(ConstitutionAction):
             role.permissions.add(p)
         role.community = self.community
         role.save()
-        self.pass_action()
 
     class Meta:
         permissions = (
@@ -723,7 +717,6 @@ class PolicykitDeleteRole(ConstitutionAction):
             self.role.delete()
         except AssertionError: # Triggers if object has already been deleted
             pass
-        self.pass_action()
 
     class Meta:
         permissions = (
@@ -752,7 +745,6 @@ class PolicykitEditRole(ConstitutionAction):
         for p in self.permissions.all():
             self.role.permissions.add(p)
         self.role.save()
-        self.pass_action()
 
     class Meta:
         permissions = (
@@ -778,7 +770,6 @@ class PolicykitAddUserRole(ConstitutionAction):
     def execute(self):
         for u in self.users.all():
             self.role.user_set.add(u)
-        self.pass_action()
 
     class Meta:
         permissions = (
@@ -804,7 +795,6 @@ class PolicykitRemoveUserRole(ConstitutionAction):
     def execute(self):
         for u in self.users.all():
             self.role.user_set.remove(u)
-        self.pass_action()
 
     class Meta:
         permissions = (
@@ -859,7 +849,6 @@ class PolicykitAddPlatformPolicy(EditorModel):
         policy.fail = self.fail
         policy.community = self.community
         policy.save()
-        self.pass_action()
 
     class Meta:
         permissions = (
@@ -885,7 +874,6 @@ class PolicykitAddConstitutionPolicy(EditorModel):
         policy.success = self.success
         policy.fail = self.fail
         policy.save()
-        self.pass_action()
 
     class Meta:
         permissions = (
@@ -910,7 +898,6 @@ class PolicykitChangePlatformPolicy(EditorModel):
         self.platform_policy.success = self.success
         self.platform_policy.fail = self.fail
         self.platform_policy.save()
-        self.pass_action()
 
     class Meta:
         permissions = (
@@ -935,7 +922,6 @@ class PolicykitChangeConstitutionPolicy(EditorModel):
         self.constitution_policy.success = self.success
         self.constitution_policy.fail = self.fail
         self.constitution_policy.save()
-        self.pass_action()
 
     class Meta:
         permissions = (
@@ -957,7 +943,6 @@ class PolicykitRemovePlatformPolicy(ConstitutionAction):
     def execute(self):
         self.platform_policy.is_active = False
         self.platform_policy.save()
-        self.pass_action()
 
     class Meta:
         permissions = (
@@ -979,7 +964,6 @@ class PolicykitRecoverPlatformPolicy(ConstitutionAction):
     def execute(self):
         self.platform_policy.is_active = True
         self.platform_policy.save()
-        self.pass_action()
 
     class Meta:
         permissions = (
@@ -1001,7 +985,6 @@ class PolicykitRemoveConstitutionPolicy(ConstitutionAction):
     def execute(self):
         self.constitution_policy.is_active = False
         self.constitution_policy.save()
-        self.pass_action()
 
     class Meta:
         permissions = (
@@ -1023,7 +1006,6 @@ class PolicykitRecoverConstitutionPolicy(ConstitutionAction):
     def execute(self):
         self.constitution_policy.is_active = True
         self.constitution_policy.save()
-        self.pass_action()
 
     class Meta:
         permissions = (
@@ -1075,8 +1057,6 @@ class PlatformAction(BaseAction, PolymorphicModel):
         Executes the action.
         """
         self.community.execute_platform_action(self)
-        # FIXME: Need to decouple this from execute
-        self.pass_action()
 
     def pass_action(self):
         """
@@ -1142,7 +1122,6 @@ class PlatformActionBundle(BaseAction):
         if self.bundle_type == PlatformActionBundle.BUNDLE:
             for action in self.bundled_actions.all():
                 self.community.execute_platform_action(action)
-                action.pass_action()
 
     def pass_action(self):
         proposal = self.proposal


### PR DESCRIPTION
Remove the remaining calls to `pass_action()` from `execute()` functions in various models in `policyengine/models.py`, `discord/models.py` and `discourse/models.py`. Since `pass_action()` is already called in `_execute_policy()`, `pass_action()` was being called twice on all actions. Since `action.send()` sends an `action was passed` log when executed and since it is called whenever `pass_action()` is called, the log was sending twice, thus appearing that all logs were duplicated in the homepage logging.