### PR TITLE
Call pass_action when the engine executes an action

### DIFF
--- a/policykit/policyengine/models.py
+++ b/policykit/policyengine/models.py
@@ -532,6 +532,7 @@ class ConstitutionAction(BaseAction, PolymorphicModel):
                     #if they have execute permission, skip all policies
                     if action.initiator.has_perm(action._meta.app_label + '.can_execute_' + action.action_codename):
                         action.execute()
+                        action.pass_action()
                     else:
                         for policy in self.community.get_constitution_policies():
                             # Execute the most recently updated policy that passes filter()
@@ -563,6 +564,7 @@ class ConstitutionActionBundle(BaseAction):
         if self.bundle_type == ConstitutionActionBundle.BUNDLE:
             for action in self.bundled_actions.all():
                 action.execute()
+                action.pass_action()
 
     def pass_action(self):
         proposal = self.proposal
@@ -585,6 +587,7 @@ class ConstitutionActionBundle(BaseAction):
                 #if they have execute permission, skip all policies
                 if action.initiator.has_perm(action._meta.app_label + '.can_execute_' + action.action_codename):
                     action.execute()
+                    action.pass_action()
                 else:
                     for policy in self.community.get_constitution_policies():
                         # Execute the most recently updated policy that passes filter()
@@ -1093,6 +1096,7 @@ class PlatformAction(BaseAction, PolymorphicModel):
                     #if they have execute permission, skip all policies
                     if action.initiator.has_perm(self._meta.app_label + '.can_execute_' + action.action_codename):
                         action.execute()
+                        action.pass_action()
                     else:
                         for policy in self.community.get_platform_policies():
                             # Execute the most recently updated policy that passes filter()
@@ -1144,6 +1148,7 @@ class PlatformActionBundle(BaseAction):
                 #if they have execute permission, skip all policies
                 if action.initiator.has_perm(action._meta.app_label + '.can_execute_' + action.action_codename):
                     action.execute()
+                    action.pass_action()
                 elif not action.community_post:
                     for policy in action.community.get_platform_policies():
                         # Execute the most recently updated policy that passes filter()

--- a/policykit/policyengine/models.py
+++ b/policykit/policyengine/models.py
@@ -530,7 +530,7 @@ class ConstitutionAction(BaseAction, PolymorphicModel):
                 if not self.is_bundled:
                     action = self
                     #if they have execute permission, skip all policies
-                    if action.initiator.has_perm(action.app_name + '.can_execute_' + action.action_codename):
+                    if action.initiator.has_perm(action._meta.app_label + '.can_execute_' + action.action_codename):
                         action.execute()
                     else:
                         for policy in self.community.get_constitution_policies():
@@ -581,9 +581,9 @@ class ConstitutionActionBundle(BaseAction):
     def save(self, *args, **kwargs):
         if not self.pk:
             action = self
-            if action.initiator.has_perm(action.app_name + '.add_' + action.action_codename):
+            if action.initiator.has_perm(action._meta.app_label + '.add_' + action.action_codename):
                 #if they have execute permission, skip all policies
-                if action.initiator.has_perm(action.app_name + '.can_execute_' + action.action_codename):
+                if action.initiator.has_perm(action._meta.app_label + '.can_execute_' + action.action_codename):
                     action.execute()
                 else:
                     for policy in self.community.get_constitution_policies():
@@ -1091,7 +1091,7 @@ class PlatformAction(BaseAction, PolymorphicModel):
                 if not self.is_bundled:
                     action = self
                     #if they have execute permission, skip all policies
-                    if action.initiator.has_perm(action.app_name + '.can_execute_' + action.action_codename):
+                    if action.initiator.has_perm(self._meta.app_label + '.can_execute_' + action.action_codename):
                         action.execute()
                     else:
                         for policy in self.community.get_platform_policies():
@@ -1140,9 +1140,9 @@ class PlatformActionBundle(BaseAction):
     def save(self, *args, **kwargs):
         if not self.pk:
             action = self
-            if action.initiator.has_perm(action.app_name + '.add_' + action.action_codename):
+            if action.initiator.has_perm(action._meta.app_label + '.add_' + action.action_codename):
                 #if they have execute permission, skip all policies
-                if action.initiator.has_perm(action.app_name + '.can_execute_' + action.action_codename):
+                if action.initiator.has_perm(action._meta.app_label + '.can_execute_' + action.action_codename):
                     action.execute()
                 elif not action.community_post:
                     for policy in action.community.get_platform_policies():

--- a/policykit/policyengine/tasks.py
+++ b/policykit/policyengine/tasks.py
@@ -8,7 +8,7 @@ from django_db_logger.models import EvaluationLog
 from policykit.settings import DB_LOG_EXPIRATION_HOURS
 
 from policyengine.models import ConstitutionAction, PlatformAction, Proposal
-from policyengine.views import execute_policy
+from policyengine.views import govern_action
 
 logger = logging.getLogger(__name__)
 
@@ -17,41 +17,16 @@ def consider_proposed_actions():
     platform_actions = PlatformAction.objects.filter(proposal__status=Proposal.PROPOSED, is_bundled=False)
     logger.info(f"{platform_actions.count()} proposed PlatformActions")
     for action in platform_actions:
-         #if they have execute permission, skip all policies
-        if action.initiator.has_perm(action._meta.app_label + '.can_execute_' + action.action_codename):
-            action.execute()
-            action.pass_action()
-        else:
-            for policy in action.community.get_platform_policies().filter(is_active=True):
-                # Execute the most recently updated policy that passes filter()
-                was_executed = execute_policy(policy, action, is_first_evaluation=False)
-                if was_executed:
-                    break
+        govern_action(action, is_first_evaluation=False)
 
     """bundle_actions = PlatformActionBundle.objects.filter(proposal__status=Proposal.PROPOSED)
     for action in bundle_actions:
-        #if they have execute permission, skip all policies
-
-        if action.initiator.has_perm(action._meta.app_label + '.can_execute_' + action.action_codename):
-            action.execute()
-            action.pass_action()
-        else:
-            for policy in action.community.get_platform_policies().filter(is_active=True):
-                execute_policy(policy, action)"""
+        govern_action(action, is_first_evaluation=False)"""
 
     constitution_actions = ConstitutionAction.objects.filter(proposal__status=Proposal.PROPOSED, is_bundled=False)
     logger.info(f"{constitution_actions.count()} proposed ConstitutionActions")
     for action in constitution_actions:
-        #if they have execute permission, skip all policies
-        if action.initiator.has_perm(action._meta.app_label + '.can_execute_' + action.action_codename):
-            action.execute()
-            action.pass_action()
-        else:
-            for policy in action.community.get_constitution_policies().filter(is_active=True):
-                # Execute the most recently updated policy that passes filter()
-                was_executed = execute_policy(policy, action, is_first_evaluation=False)
-                if was_executed:
-                    break
+        govern_action(action, is_first_evaluation=False)
 
     clean_up_logs()
     logger.info('finished task')

--- a/policykit/policyengine/tasks.py
+++ b/policykit/policyengine/tasks.py
@@ -20,6 +20,7 @@ def consider_proposed_actions():
          #if they have execute permission, skip all policies
         if action.initiator.has_perm(action._meta.app_label + '.can_execute_' + action.action_codename):
             action.execute()
+            action.pass_action()
         else:
             for policy in action.community.get_platform_policies().filter(is_active=True):
                 # Execute the most recently updated policy that passes filter()
@@ -33,6 +34,7 @@ def consider_proposed_actions():
 
         if action.initiator.has_perm(action._meta.app_label + '.can_execute_' + action.action_codename):
             action.execute()
+            action.pass_action()
         else:
             for policy in action.community.get_platform_policies().filter(is_active=True):
                 execute_policy(policy, action)"""
@@ -43,6 +45,7 @@ def consider_proposed_actions():
         #if they have execute permission, skip all policies
         if action.initiator.has_perm(action._meta.app_label + '.can_execute_' + action.action_codename):
             action.execute()
+            action.pass_action()
         else:
             for policy in action.community.get_constitution_policies().filter(is_active=True):
                 # Execute the most recently updated policy that passes filter()

--- a/policykit/policyengine/tasks.py
+++ b/policykit/policyengine/tasks.py
@@ -18,7 +18,7 @@ def consider_proposed_actions():
     logger.info(f"{platform_actions.count()} proposed PlatformActions")
     for action in platform_actions:
          #if they have execute permission, skip all policies
-        if action.initiator.has_perm(action.app_name + '.can_execute_' + action.action_codename):
+        if action.initiator.has_perm(action._meta.app_label + '.can_execute_' + action.action_codename):
             action.execute()
         else:
             for policy in action.community.get_platform_policies().filter(is_active=True):
@@ -31,7 +31,7 @@ def consider_proposed_actions():
     for action in bundle_actions:
         #if they have execute permission, skip all policies
 
-        if action.initiator.has_perm(action.app_name + '.can_execute_' + action.action_codename):
+        if action.initiator.has_perm(action._meta.app_label + '.can_execute_' + action.action_codename):
             action.execute()
         else:
             for policy in action.community.get_platform_policies().filter(is_active=True):
@@ -41,7 +41,7 @@ def consider_proposed_actions():
     logger.info(f"{constitution_actions.count()} proposed ConstitutionActions")
     for action in constitution_actions:
         #if they have execute permission, skip all policies
-        if action.initiator.has_perm(action.app_name + '.can_execute_' + action.action_codename):
+        if action.initiator.has_perm(action._meta.app_label + '.can_execute_' + action.action_codename):
             action.execute()
         else:
             for policy in action.community.get_constitution_policies().filter(is_active=True):

--- a/policykit/policyengine/views.py
+++ b/policykit/policyengine/views.py
@@ -246,8 +246,6 @@ def roleeditor(request):
 
 @login_required(login_url='/login')
 def selectpolicy(request):
-    from policyengine.models import PlatformPolicy, ConstitutionPolicy
-
     user = get_user(request)
     policies = None
     type = request.GET.get('type')
@@ -274,8 +272,6 @@ def selectpolicy(request):
 
 @login_required(login_url='/login')
 def selectdocument(request):
-    from policyengine.models import CommunityDoc
-
     user = get_user(request)
     operation = request.GET.get('operation')
 
@@ -724,6 +720,36 @@ def document_action_recover(request):
     action.save()
 
     return HttpResponse()
+
+def govern_action(action, is_first_evaluation: bool):
+    """
+    Govern platform and constitution actions:
+    - If the initiator has "can execute" permission, execute the action and mark it as "passed."
+    - Otherwise, try executing the relevant policies. Stop at the first policy that passes the `filter` step.
+
+    This can be run repeatedly to check proposed actions.
+    """
+    from policyengine.models import PlatformAction, PlatformActionBundle, ConstitutionAction, ConstitutionActionBundle
+
+    #if they have execute permission, skip all policies
+    if action.initiator.has_perm(action._meta.app_label + '.can_execute_' + action.action_codename):
+        action.execute()
+        action.pass_action()
+    else:
+        policies = None
+        if isinstance(action, PlatformAction) or isinstance(action, PlatformActionBundle):
+            policies = action.community.get_platform_policies().filter(is_active=True)
+        elif isinstance(action, ConstitutionAction) or isinstance(action, ConstitutionActionBundle):
+            policies = action.community.get_constitution_policies().filter(is_active=True)
+        else:
+            raise Exception("govern_action: unrecognized action")
+
+        for policy in policies:
+            # Execute the most recently updated policy that passes filter()
+            was_executed = execute_policy(policy, action, is_first_evaluation=is_first_evaluation)
+            if was_executed:
+                break
+
 
 def execute_policy(policy, action, is_first_evaluation: bool):
     """

--- a/policykit/tests/test_policy_evaluation.py
+++ b/policykit/tests/test_policy_evaluation.py
@@ -1,14 +1,11 @@
-import json
 from unittest import skip
 
-import requests
 from django.contrib.auth.models import Permission
 from django.test import Client, TestCase
 from integrations.metagov.library import update_metagov_community, metagov_slug
-from integrations.metagov.models import MetagovProcess, MetagovPlatformAction, MetagovUser
-from integrations.slack.models import SlackCommunity, SlackPinMessage, SlackStarterKit, SlackUser
-from policyengine.models import CommunityRole, PlatformAction, PlatformPolicy, Proposal
-from policyengine.views import check_policy, filter_policy
+from integrations.metagov.models import MetagovProcess, MetagovPlatformAction
+from integrations.slack.models import SlackCommunity, SlackPinMessage, SlackUser
+from policyengine.models import CommunityRole, PlatformPolicy
 
 all_actions_pass_policy = {
     "filter": "return True",
@@ -68,13 +65,13 @@ class EvaluationTests(TestCase):
 
         # action initiated by user with "can_execute" should pass
         action = SlackPinMessage(initiator=self.user_with_can_execute, community=self.community)
-        action.execute = lambda: None # don't do anything on execute
+        action.execute = lambda: None  # don't do anything on execute
         action.save()
         self.assertEqual(action.proposal.status, "passed")
 
         # action initiated by user without "can_execute" should fail
         action = SlackPinMessage(initiator=self.user, community=self.community)
-        action.execute = lambda: None # don't do anything on execute
+        action.execute = lambda: None  # don't do anything on execute
         action.save()
         self.assertEqual(action.proposal.status, "failed")
 


### PR DESCRIPTION
Follow-up to https://github.com/amyxzhang/policykit/pull/387 to fix a bug. The bug was that actions executed because the user had `can_execute_*` permission were left in "proposed" state. Additionally some of the `has_perm` checks for can_execute were not working properly because they used the wrong app label prefix.

The code be easiest to review commit-by-commit, since I included a refactor to pull out some repeated code.
This commit is what fixes the bug: https://github.com/amyxzhang/policykit/commit/10e85a07293096f9a8c24c16d5e1969751c9975c

