### PR TITLE
Add ability to upload and download policies

### DIFF
--- a/policykit/policyengine/views.py
+++ b/policykit/policyengine/views.py
@@ -150,7 +150,6 @@ def editor(request):
     type = request.GET.get('type')
     operation = request.GET.get('operation')
     policy_id = request.GET.get('policy')
-    use_saved_policy = request.GET.get('use_saved_policy')
 
     data = {
         'server_url': SERVER_URL,
@@ -178,33 +177,7 @@ def editor(request):
         data['success'] = policy.success
         data['fail'] = policy.fail
 
-    elif use_saved_policy.lower() == 'true': # Boolean auto-converted to string so need to check in this way
-        data['name'] = request.session['policy_name']
-        data['description'] = request.session['policy_description']
-        data['filter'] = request.session['policy_filter']
-        data['initialize'] = request.session['policy_initialize']
-        data['check'] = request.session['policy_check']
-        data['notify'] = request.session['policy_notify']
-        data['success'] = request.session['policy_success']
-        data['fail'] = request.session['policy_fail']
-
     return render(request, 'policyadmin/dashboard/editor.html', data)
-
-@csrf_exempt
-def editor_upload(request):
-    data = json.loads(request.body.decode('utf-8'))
-
-    request.session['policy_name'] = data['name']
-    request.session['policy_description'] = data['description']
-    request.session['policy_is_bundled'] = data['is_bundled']
-    request.session['policy_filter'] = data['filter']
-    request.session['policy_initialize'] = data['initialize']
-    request.session['policy_check'] = data['check']
-    request.session['policy_notify'] = data['notify']
-    request.session['policy_success'] = data['success']
-    request.session['policy_fail'] = data['fail']
-
-    return HttpResponse()
 
 @login_required(login_url='/login')
 def selectrole(request):

--- a/policykit/policykit/urls.py
+++ b/policykit/policykit/urls.py
@@ -23,7 +23,6 @@ urlpatterns = [
     path('logout/', policyviews.logout, name="logout"),
     path('main/', policyviews.v2),
     path('main/editor/', policyviews.editor),
-    path('main/editor_upload/', policyviews.editor_upload),
     path('main/selectrole/', policyviews.selectrole),
     path('main/roleusers/', policyviews.roleusers),
     path('main/roleeditor/', policyviews.roleeditor),

--- a/policykit/policykit/urls.py
+++ b/policykit/policykit/urls.py
@@ -23,6 +23,7 @@ urlpatterns = [
     path('logout/', policyviews.logout, name="logout"),
     path('main/', policyviews.v2),
     path('main/editor/', policyviews.editor),
+    path('main/editor_upload/', policyviews.editor_upload),
     path('main/selectrole/', policyviews.selectrole),
     path('main/roleusers/', policyviews.roleusers),
     path('main/roleeditor/', policyviews.roleeditor),

--- a/policykit/templates/policyadmin/dashboard/actions.html
+++ b/policykit/templates/policyadmin/dashboard/actions.html
@@ -132,7 +132,10 @@
   </div>
   <div class="actionCollapsible" id="constitutionPolicies">
     <div class="actionButton" id="addConstitutionPolicy">
-      <p>Add Constitution Policy</p>
+      <p>New Constitution Policy</p>
+    </div>
+    <div class="actionButton" id="uploadConstitutionPolicy">
+      <p>Upload Constitution Policy</p>
     </div>
     <div class="actionButton" id="editConstitutionPolicy">
       <p>Edit Constitution Policy</p>
@@ -151,7 +154,10 @@
   </div>
   <div class="actionCollapsible" id="platformPolicies">
     <div class="actionButton" id="addPlatformPolicy">
-      <p>Add Platform Policy</p>
+      <p>New Platform Policy</p>
+    </div>
+    <div class="actionButton" id="uploadPlatformPolicy">
+      <p>Upload Platform Policy</p>
     </div>
     <div class="actionButton" id="editPlatformPolicy">
       <p>Edit Platform Policy</p>
@@ -170,7 +176,7 @@
   </div>
   <div class="actionCollapsible" id="roles">
     <div class="actionButton" id="addRole">
-      <p>Add Role</p>
+      <p>New Role</p>
     </div>
     <div class="actionButton" id="editRole">
       <p>Edit Role</p>
@@ -192,7 +198,7 @@
   </div>
   <div class="actionCollapsible" id="documents">
     <div class="actionButton" id="addDocument">
-      <p>Add Document</p>
+      <p>New Document</p>
     </div>
     <div class="actionButton" id="editDocument">
       <p>Edit Document</p>
@@ -216,10 +222,12 @@
   document.getElementById("documentsHeader").addEventListener("click", toggleActionMenu);
 
   document.getElementById("addConstitutionPolicy").addEventListener("click", function(){ navEditor('Constitution', 'Add'); });
+  document.getElementById("uploadConstitutionPolicy").addEventListener("click", function(){ uploadPolicy('Constitution'); });
   document.getElementById("editConstitutionPolicy").addEventListener("click", function(){ navPolicySelect('Constitution', 'Change'); });
   document.getElementById("removeConstitutionPolicy").addEventListener("click", function(){ navPolicySelect('Constitution', "Remove"); });
   document.getElementById("recoverConstitutionPolicy").addEventListener("click", function(){ navPolicySelect('Constitution', "Recover"); });
   document.getElementById("addPlatformPolicy").addEventListener("click", function(){ navEditor('Platform', 'Add'); });
+  document.getElementById("uploadPlatformPolicy").addEventListener("click", function(){ uploadPolicy('Platform'); });
   document.getElementById("editPlatformPolicy").addEventListener("click", function(){ navPolicySelect('Platform', 'Change'); });
   document.getElementById("removePlatformPolicy").addEventListener("click", function(){ navPolicySelect('Platform', "Remove"); });
   document.getElementById("recoverPlatformPolicy").addEventListener("click", function(){ navPolicySelect('Platform', "Recover"); });
@@ -242,32 +250,66 @@
     }
   }
 
-  function navEditor(type, operation) {
-    window.location.href = `{{server_url}}/main/editor?type=${type}&operation=${operation}`
+  function navEditor(type, operation, use_saved_policy=false) {
+    window.location.href = `{{server_url}}/main/editor?type=${type}&operation=${operation}&use_saved_policy=${use_saved_policy}`;
   }
 
   function navPolicySelect(type, operation) {
-    window.location.href = `{{server_url}}/main/selectpolicy?type=${type}&operation=${operation}`
+    window.location.href = `{{server_url}}/main/selectpolicy?type=${type}&operation=${operation}`;
   }
 
   function navRoleAdd() {
-    window.location.href = `{{server_url}}/main/roleeditor?operation=Add`
+    window.location.href = `{{server_url}}/main/roleeditor?operation=Add`;
   }
 
   function navRoleSelect(operation) {
-    window.location.href = `{{server_url}}/main/selectrole?operation=${operation}`
+    window.location.href = `{{server_url}}/main/selectrole?operation=${operation}`;
   }
 
   function navRoleUsers(operation) {
-    window.location.href = `{{server_url}}/main/roleusers?operation=${operation}`
+    window.location.href = `{{server_url}}/main/roleusers?operation=${operation}`;
   }
 
   function navDocumentAdd() {
-    window.location.href = `{{server_url}}/main/documenteditor?operation=Add`
+    window.location.href = `{{server_url}}/main/documenteditor?operation=Add`;
   }
 
   function navDocumentSelect(operation) {
-    window.location.href = `{{server_url}}/main/selectdocument?operation=${operation}`
+    window.location.href = `{{server_url}}/main/selectdocument?operation=${operation}`;
+  }
+
+  function uploadPolicy(type) {
+    // User selects which policy they would like to upload. Policy is read into a json object.
+    let input_elem = document.createElement('input');
+    input_elem.type = 'file';
+    input_elem.onchange = e => {
+      let reader = new FileReader();
+      reader.onload = e => {
+        let policy_data = JSON.parse(e.target.result);
+
+        fetch(`../../../main/editor_upload/`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json'
+          },
+          body: JSON.stringify({
+            'name': policy_data.name,
+            'description': policy_data.description,
+            'is_bundled': policy_data.is_bundled,
+            'filter': policy_data.filter,
+            'initialize': policy_data.initialize,
+            'check': policy_data.check,
+            'notify': policy_data.notify,
+            'success': policy_data.success,
+            'fail': policy_data.fail
+          })
+        }).then(response => {
+          navEditor(type, 'Add', true);
+        });
+      }
+      reader.readAsText(e.target.files[0]);
+    }
+    input_elem.click();
   }
 </script>
 {% endblock %}

--- a/policykit/templates/policyadmin/dashboard/actions.html
+++ b/policykit/templates/policyadmin/dashboard/actions.html
@@ -220,12 +220,10 @@
 {% block scripts %}
 <script>
   document.getElementById("addConstitutionPolicy").addEventListener("click", function(){ navEditor('Constitution', 'Add'); });
-  document.getElementById("uploadConstitutionPolicy").addEventListener("click", function(){ uploadPolicy('Constitution'); });
   document.getElementById("editConstitutionPolicy").addEventListener("click", function(){ navPolicySelect('Constitution', 'Change'); });
   document.getElementById("removeConstitutionPolicy").addEventListener("click", function(){ navPolicySelect('Constitution', "Remove"); });
   document.getElementById("recoverConstitutionPolicy").addEventListener("click", function(){ navPolicySelect('Constitution', "Recover"); });
   document.getElementById("addPlatformPolicy").addEventListener("click", function(){ navEditor('Platform', 'Add'); });
-  document.getElementById("uploadPlatformPolicy").addEventListener("click", function(){ uploadPolicy('Platform'); });
   document.getElementById("editPlatformPolicy").addEventListener("click", function(){ navPolicySelect('Platform', 'Change'); });
   document.getElementById("removePlatformPolicy").addEventListener("click", function(){ navPolicySelect('Platform', "Remove"); });
   document.getElementById("recoverPlatformPolicy").addEventListener("click", function(){ navPolicySelect('Platform', "Recover"); });
@@ -265,40 +263,6 @@
 
   function navDocumentSelect(operation) {
     window.location.href = `{{server_url}}/main/selectdocument?operation=${operation}`;
-  }
-
-  function uploadPolicy(type) {
-    // User selects which policy they would like to upload. Policy is read into a json object.
-    let input_elem = document.createElement('input');
-    input_elem.type = 'file';
-    input_elem.onchange = e => {
-      let reader = new FileReader();
-      reader.onload = e => {
-        let policy_data = JSON.parse(e.target.result);
-
-        fetch(`../../../main/editor_upload/`, {
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/json'
-          },
-          body: JSON.stringify({
-            'name': policy_data.name,
-            'description': policy_data.description,
-            'is_bundled': policy_data.is_bundled,
-            'filter': policy_data.filter,
-            'initialize': policy_data.initialize,
-            'check': policy_data.check,
-            'notify': policy_data.notify,
-            'success': policy_data.success,
-            'fail': policy_data.fail
-          })
-        }).then(response => {
-          navEditor(type, 'Add', true);
-        });
-      }
-      reader.readAsText(e.target.files[0]);
-    }
-    input_elem.click();
   }
 </script>
 {% endblock %}

--- a/policykit/templates/policyadmin/dashboard/editor.html
+++ b/policykit/templates/policyadmin/dashboard/editor.html
@@ -113,6 +113,13 @@
   </div>
 
   <div class="form-row">
+    <div class="col-sm-1"></div>
+    <div class="col-sm-11">
+      <button type="button" class="btn" id="upload">Upload policy</button>
+    </div>
+  </div>
+
+  <div class="form-row">
     <label class="control-label col-sm-1" for="name">Name</label>
     <div class="col-sm-11">
       <input type="text" class="form-control name" id="name" required>
@@ -198,6 +205,7 @@
 <script src={% static "codemirror/addon/hint/css-hint.js" %}></script>
 
 <script>
+  document.getElementById("upload").addEventListener("click", upload);
   document.getElementById("propose").addEventListener("click", propose);
   document.getElementById("download").addEventListener("click", download);
   document.getElementById("documentation").addEventListener("click", documentation);
@@ -238,36 +246,6 @@
     }).then(response => {
       window.location.href = "{{server_url}}/main/";
     });
-  }
-
-  function download() {
-    const name = document.getElementById("name").value;
-
-    let policy_data = {
-      'name': name,
-      'description': document.getElementById("description").value,
-      'is_bundled': false,
-      'filter': document.getElementById("filter").nextSibling.CodeMirror.getValue(),
-      'initialize': document.getElementById("initialize").nextSibling.CodeMirror.getValue(),
-      'check': document.getElementById("check").nextSibling.CodeMirror.getValue(),
-      'notify': document.getElementById("notify").nextSibling.CodeMirror.getValue(),
-      'success': document.getElementById("pass").nextSibling.CodeMirror.getValue(),
-      'fail': document.getElementById("fail").nextSibling.CodeMirror.getValue()
-    };
-
-    let policy_data_string = 'data:text/json;charset=utf-8,' + encodeURIComponent(JSON.stringify(policy_data));
-
-    // Only allow alphanumeric characters and underscores in the filename
-    let filename = name.replace(/[^0-9a-zA-Z]/g, "_") + ".txt";
-
-    // https://stackoverflow.com/questions/45831191/generate-and-download-file-from-js
-    let download_elem = document.createElement('a');
-    download_elem.setAttribute('href', policy_data_string);
-    download_elem.setAttribute('download', filename);
-    download_elem.style.display = 'none';
-    document.body.appendChild(download_elem);
-    download_elem.click();
-    document.body.removeChild(download_elem);
   }
 
   // https://stackoverflow.com/questions/7394748/whats-the-right-way-to-decode-a-string-that-has-special-html-entities-in-it
@@ -386,6 +364,76 @@
         }
       })
     })
+  }
+
+  function is_policy_default() {
+    if (document.getElementById('name').value != "") {
+      return false;
+    }
+    if (document.getElementById('description').value != "") {
+      return false;
+    }
+    for (let i = 0; i < Object.keys(DEFAULT_VALUES).length; i++) {
+      if (editors[i].getValue() != Object.values(DEFAULT_VALUES)[i]) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  function upload(type) {
+    if (is_policy_default() || confirm("Warning: This will overwrite your policy code! Are you sure you want to upload a policy?")) {
+      // User selects which policy they would like to upload. Policy is read into a json object.
+      let input_elem = document.createElement('input');
+      input_elem.type = 'file';
+      input_elem.onchange = e => {
+        let reader = new FileReader();
+        reader.onload = e => {
+          let policy_data = JSON.parse(e.target.result);
+
+          document.getElementById('name').value = decodeHtml(`${policy_data.name}`);
+          document.getElementById('description').value = decodeHtml(`${policy_data.description}`);
+          editors[0].setValue(decodeHtml(`${policy_data.filter}`));
+          editors[1].setValue(decodeHtml(`${policy_data.initialize}`));
+          editors[2].setValue(decodeHtml(`${policy_data.check}`));
+          editors[3].setValue(decodeHtml(`${policy_data.notify}`));
+          editors[4].setValue(decodeHtml(`${policy_data.success}`));
+          editors[5].setValue(decodeHtml(`${policy_data.fail}`));
+        }
+        reader.readAsText(e.target.files[0]);
+      }
+      input_elem.click();
+    }
+  }
+
+  function download() {
+    const name = document.getElementById("name").value;
+
+    let policy_data = {
+      'name': name,
+      'description': document.getElementById("description").value,
+      'is_bundled': false,
+      'filter': document.getElementById("filter").nextSibling.CodeMirror.getValue(),
+      'initialize': document.getElementById("initialize").nextSibling.CodeMirror.getValue(),
+      'check': document.getElementById("check").nextSibling.CodeMirror.getValue(),
+      'notify': document.getElementById("notify").nextSibling.CodeMirror.getValue(),
+      'success': document.getElementById("pass").nextSibling.CodeMirror.getValue(),
+      'fail': document.getElementById("fail").nextSibling.CodeMirror.getValue()
+    };
+
+    let policy_data_string = 'data:text/json;charset=utf-8,' + encodeURIComponent(JSON.stringify(policy_data));
+
+    // Only allow alphanumeric characters and underscores in the filename
+    let filename = name.replace(/[^0-9a-zA-Z]/g, "_") + ".txt";
+
+    // https://stackoverflow.com/questions/45831191/generate-and-download-file-from-js
+    let download_elem = document.createElement('a');
+    download_elem.setAttribute('href', policy_data_string);
+    download_elem.setAttribute('download', filename);
+    download_elem.style.display = 'none';
+    document.body.appendChild(download_elem);
+    download_elem.click();
+    document.body.removeChild(download_elem);
   }
 </script>
 {% endblock %}

--- a/policykit/templates/policyadmin/dashboard/editor.html
+++ b/policykit/templates/policyadmin/dashboard/editor.html
@@ -147,7 +147,7 @@
       <div class="col-sm-1"></div>
       <div class="col-sm-11">
         <button type="button" class="btn btn-success" id="propose">Propose Policy</button>
-        <button type="button" class="btn btn-warning" id="addtobundle">Add to Policy Bundle</button>
+        <button type="button" class="btn btn-warning" id="download">Download Policy</button>
         <button type = "button" class = "btn btn-warning" id="documentation">Open PolicyKit Documentation</button>
       </div>
     </div>
@@ -169,30 +169,24 @@
 <script src={% static "codemirror/addon/hint/show-hint.css" %}></script>
 <script src={% static "codemirror/addon/hint/css-hint.js" %}></script>
 
-
 <script>
   document.getElementById("propose").addEventListener("click", propose);
-  document.getElementById("addtobundle").addEventListener("click", addToBundle);
+  document.getElementById("download").addEventListener("click", download);
   document.getElementById("documentation").addEventListener("click", documentation);
 
   function documentation() {
-      window.open(`https://policykit.readthedocs.io/en/latest/index.html`, '_blank');
+    window.open(`https://policykit.readthedocs.io/en/latest/index.html`, '_blank');
   }
 
-function propose() {
-    const urlParams = new URLSearchParams(window.location.search);
-    const type = urlParams.get('type');
-    const operation = urlParams.get('operation');
-    const policy = urlParams.get('policy');
-
-    const name = document.getElementById("name").value
-    const description = document.getElementById("description").value
-    const filter = document.getElementById("filter").nextSibling.CodeMirror.getValue()
-    const initialize = document.getElementById("initialize").nextSibling.CodeMirror.getValue()
-    const check = document.getElementById("check").nextSibling.CodeMirror.getValue()
-    const notify = document.getElementById("notify").nextSibling.CodeMirror.getValue()
-    const success = document.getElementById("pass").nextSibling.CodeMirror.getValue()
-    const fail = document.getElementById("fail").nextSibling.CodeMirror.getValue()
+  function propose() {
+    const name = document.getElementById("name").value;
+    const description = document.getElementById("description").value;
+    const filter = document.getElementById("filter").nextSibling.CodeMirror.getValue();
+    const initialize = document.getElementById("initialize").nextSibling.CodeMirror.getValue();
+    const check = document.getElementById("check").nextSibling.CodeMirror.getValue();
+    const notify = document.getElementById("notify").nextSibling.CodeMirror.getValue();
+    const success = document.getElementById("pass").nextSibling.CodeMirror.getValue();
+    const fail = document.getElementById("fail").nextSibling.CodeMirror.getValue();
 
     fetch('../../../main/policyengine/policy_action_save', {
       method: 'POST',
@@ -200,9 +194,9 @@ function propose() {
         'Content-Type': 'application/json'
       },
       body: JSON.stringify({
-        'type': type,
-        'operation': operation,
-        'policy': policy,
+        'type': `{{type}}`,
+        'operation': `{{operation}}`,
+        'policy': `{{policy}}`,
         'name': name,
         'description': description,
         'is_bundled': false,
@@ -214,13 +208,38 @@ function propose() {
         'fail': fail
       })
     }).then(response => {
-      window.location.href = "{{server_url}}/main/"
+      window.location.href = "{{server_url}}/main/";
     });
   }
 
-  function addToBundle() {
-    // TODO: Implement add to bundle functionality here
-    window.location.href = "{{server_url}}/main/"
+  function download() {
+    const name = document.getElementById("name").value;
+
+    let policy_data = {
+      'name': name,
+      'description': document.getElementById("description").value,
+      'is_bundled': false,
+      'filter': document.getElementById("filter").nextSibling.CodeMirror.getValue(),
+      'initialize': document.getElementById("initialize").nextSibling.CodeMirror.getValue(),
+      'check': document.getElementById("check").nextSibling.CodeMirror.getValue(),
+      'notify': document.getElementById("notify").nextSibling.CodeMirror.getValue(),
+      'success': document.getElementById("pass").nextSibling.CodeMirror.getValue(),
+      'fail': document.getElementById("fail").nextSibling.CodeMirror.getValue()
+    };
+
+    let policy_data_string = 'data:text/json;charset=utf-8,' + encodeURIComponent(JSON.stringify(policy_data));
+
+    // Only allow alphanumeric characters and underscores in the filename
+    let filename = name.replace(/[^0-9a-zA-Z]/g, "_") + ".txt";
+
+    // https://stackoverflow.com/questions/45831191/generate-and-download-file-from-js
+    let download_elem = document.createElement('a');
+    download_elem.setAttribute('href', policy_data_string);
+    download_elem.setAttribute('download', filename);
+    download_elem.style.display = 'none';
+    document.body.appendChild(download_elem);
+    download_elem.click();
+    document.body.removeChild(download_elem);
   }
 
   // https://stackoverflow.com/questions/7394748/whats-the-right-way-to-decode-a-string-that-has-special-html-entities-in-it

--- a/policykit/templates/policyadmin/dashboard/index.html
+++ b/policykit/templates/policyadmin/dashboard/index.html
@@ -162,6 +162,21 @@
     margin-bottom: 1vh;
   }
 
+  .btn {
+    padding: 0.5em 2vw;
+    margin-right: 0.4vw;
+    border: 1px solid #4451b2;
+    font-family: 'Nunito', sans-serif;
+    font-size: 1.2em;
+    background-color: #ffffff;
+    color: #4451b2;
+  }
+
+  .btn:hover {
+    background-color: #4451b2;
+    color: #ffffff;
+  }
+
   .form-row {
     margin-bottom: 2vh;
   }
@@ -407,7 +422,7 @@
     <div class="form-row">
       <div class="col-sm-1"></div>
       <div class="col-sm-11">
-        <button type="button" class="btn btn-warning" id="download">Download Policy</button>
+        <button type="button" class="btn" id="download">Download policy</button>
       </div>
     </div>
   </div>

--- a/policykit/templates/policyadmin/dashboard/index.html
+++ b/policykit/templates/policyadmin/dashboard/index.html
@@ -469,6 +469,13 @@
         <textarea class="form-control code" id="fail" readonly rows="3"></textarea>
       </div>
     </div>
+
+    <div class="form-row">
+      <div class="col-sm-1"></div>
+      <div class="col-sm-11">
+        <button type="button" class="btn btn-warning" id="download">Download Policy</button>
+      </div>
+    </div>
   </div>
 </div>
 {% endblock %}
@@ -479,7 +486,10 @@
 <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.56.0/addon/display/autorefresh.min.js"></script>
 
 <script>
+  document.getElementById("download").addEventListener("click", download);
+
   document.getElementById("proposeAction").addEventListener("click", navActions);
+
   {% for key, value in platform_policies.items %}
     document.getElementById("platform_{{key}}").addEventListener("click", function(){ showModal('code', {
       name: `{{value.name}}`,
@@ -492,6 +502,7 @@
       fail: `{{value.fail}}`
     }); });
   {% endfor %}
+
   {% for key, value in constitution_policies.items %}
     document.getElementById("constitution_{{key}}").addEventListener("click", function(){ showModal('code', {
       name: `{{value.name}}`,
@@ -504,16 +515,19 @@
       fail: `{{value.fail}}`
     }); });
   {% endfor %}
+
   {% for key, value in docs.items %}
     document.getElementById("document_{{key}}").addEventListener("click", function(){ showModal('doc', {
       name: `{{value.name}}`,
       text: `{{value.text}}`
     }); });
   {% endfor %}
+
   modals = document.getElementsByClassName("modal");
   for (let i = 0; i < modals.length; i++) {
     modals[i].addEventListener("click", hideModal);
   }
+
   closeButtons = document.getElementsByClassName("close");
   for (let i = 0; i < closeButtons.length; i++) {
     closeButtons[i].addEventListener("click", hideModal);
@@ -577,6 +591,36 @@
     for (let i = 0; i < modals.length; i++) {
       modals[i].style.display = "none";
     }
+  }
+
+  function download() {
+    const name = document.getElementById("name").value;
+
+    let policy_data = {
+      'name': name,
+      'description': document.getElementById("description").value,
+      'is_bundled': false,
+      'filter': document.getElementById("filter").nextSibling.CodeMirror.getValue(),
+      'initialize': document.getElementById("initialize").nextSibling.CodeMirror.getValue(),
+      'check': document.getElementById("check").nextSibling.CodeMirror.getValue(),
+      'notify': document.getElementById("notify").nextSibling.CodeMirror.getValue(),
+      'success': document.getElementById("pass").nextSibling.CodeMirror.getValue(),
+      'fail': document.getElementById("fail").nextSibling.CodeMirror.getValue()
+    };
+
+    let policy_data_string = 'data:text/json;charset=utf-8,' + encodeURIComponent(JSON.stringify(policy_data));
+
+    // Only allow alphanumeric characters and underscores in the filename
+    let filename = name.replace(/[^0-9a-zA-Z]/g, "_") + ".txt";
+
+    // https://stackoverflow.com/questions/45831191/generate-and-download-file-from-js
+    let download_elem = document.createElement('a');
+    download_elem.setAttribute('href', policy_data_string);
+    download_elem.setAttribute('download', filename);
+    download_elem.style.display = 'none';
+    document.body.appendChild(download_elem);
+    download_elem.click();
+    document.body.removeChild(download_elem);
   }
 </script>
 {% endblock %}


### PR DESCRIPTION
Previously, it was tedious to try out policies that someone else developed or to recreate policies on new communities. Each code block had to be copy/pasted individually. This PR allows users to download policies (from both the editor and from the list of passed policies) into a text file (containing a JSON representation of the policy). Users are also able to upload policies -- a new option is added to the Platform Policies and Constitution Policies menus on `actions.html` called `Upload Platform Policy` and `Upload Constitution Policy` respectively. Upon clicking either option, a file dialog is opened. The user can select a policy from the file dialog and the editor will be opened with the policy automatically loaded in.

<img width="826" alt="Screen Shot 2021-05-19 at 2 53 35 PM" src="https://user-images.githubusercontent.com/30058947/118890149-0ce62c00-b8b3-11eb-9ac8-4d6ee61bdbcb.png">
<img width="576" alt="Screen Shot 2021-05-19 at 2 53 44 PM" src="https://user-images.githubusercontent.com/30058947/118890150-0d7ec280-b8b3-11eb-8bf2-abe6e304fde8.png">
<img width="1053" alt="Screen Shot 2021-05-19 at 2 54 03 PM" src="https://user-images.githubusercontent.com/30058947/118890151-0e175900-b8b3-11eb-9746-bfa149860ced.png">
