### PR TITLE
Correction for DRIVER_EVENT_RECEIVER_URL place

### DIFF
--- a/docs/source/integrations.rst
+++ b/docs/source/integrations.rst
@@ -110,7 +110,7 @@ Initial Setup
 To use Metagov with PolicyKit, the server admin needs to do this once:
 
 1. Deploy an instance of Metagov on the same machine as PolicyKit. See `Installing Metagov <https://docs.metagov.org/en/latest/installation.html>`_ for instructions.
-2. In the ``.env`` file in PolicyKit, set the URL for receiving events: ``DRIVER_EVENT_RECEIVER_URL=[POLICYKIT_URL]/metagov/internal/action``
+2. In the ``.env`` file in Metagov, set the URL for receiving events: ``DRIVER_EVENT_RECEIVER_URL=[POLICYKIT_URL]/metagov/internal/action``
 3. To enable Metagov in PolicyKit, set the ``METAGOV_URL`` in your ``private.py`` file to point to your Metagov instance.
 4. Ensure that ``/metagov/internal`` is restricted to local traffic. Follow the Apache2 example in :doc:`Getting Started <../gettingstarted>`.
 


### PR DESCRIPTION
DRIVER_EVENT_RECEIVER_URL is an env that only exists within metagov, and is only used by metagov, and also pk doesn't use .env files anywhere