### PR TITLE
Add guilds scope to Discord login

### DIFF
--- a/policykit/templates/policyadmin/login.html
+++ b/policykit/templates/policyadmin/login.html
@@ -95,7 +95,7 @@ You must be an admin of the Discord to add PolicyKit to your server.<BR>
 
 <P>
 
-<a href="https://discordapp.com/api/oauth2/authorize?client_id={{discord_client_id}}&response_type=code&redirect_uri={{server_url}}%2Fdiscord%2Foauth&scope=identify&state=policykit_discord_user_login">
+<a href="https://discordapp.com/api/oauth2/authorize?client_id={{discord_client_id}}&response_type=code&redirect_uri={{server_url}}%2Fdiscord%2Foauth&scope=identify%20guilds&state=policykit_discord_user_login">
   Sign in with Discord
 </a>
 


### PR DESCRIPTION
`guilds` scope is required for this request: https://github.com/amyxzhang/policykit/blob/40a28f03fbe61c59dcb9a1cd3365e6c309b1f8e5/policykit/integrations/discord/views.py#L362-L366


thanks @hozzjss for finding this bug