### PR TITLE
Remove websocket module from requirements.txt

### DIFF
--- a/policykit/requirements.txt
+++ b/policykit/requirements.txt
@@ -74,7 +74,6 @@ typing-extensions==3.7.4.3
 urllib3==1.25.8
 vine==1.3.0
 wcwidth==0.1.8
-websocket==0.2.1
 websocket-client==0.58.0
 zipp==2.0.1
 zope.event==4.5.0


### PR DESCRIPTION
Should only use `websocket-client` module, otherwise an error is produced because the two modules interfere with each other.