### PR TITLE
Update installation docs to work for Apache 2.4

### DIFF
--- a/docs/source/gettingstarted.rst
+++ b/docs/source/gettingstarted.rst
@@ -148,9 +148,9 @@ Make sure you have a domain dedicated to Policykit that is pointing to your serv
                                 </Files>
                         </Directory>
 
-                        # 🚨 IMPORTANT if using Metagov: Restrict internal endpoints to local traffic 🚨
+                        # 🚨 IMPORTANT: Restrict internal endpoints to local traffic 🚨
                         <Location /metagov/internal>
-                                Require local
+                                Require ip YOUR-IP-ADDRESS
                         </Location>
 
                         WSGIDaemonProcess policykit python-home=$POLICYKIT_ENV python-path=$POLICYKIT_REPO/policykit
@@ -222,19 +222,21 @@ For more information about configuration options, see the `Celery Daemonization 
 Create RabbitMQ virtual host
 """"""""""""""""""""""""""""
 
-Install RabbitMQ:
+Install RabbitMQ and create a virtual host:
 
 .. code-block:: shell
 
     sudo apt-get install rabbitmq-server
 
-Follow these instruction to `create a RabbitMQ username, password, and virtual host <https://docs.celeryproject.org/en/stable/getting-started/brokers/rabbitmq.html#setting-up-rabbitmq>`_.
+    sudo rabbitmqctl add_user 'username' 'password'
+    sudo rabbitmqctl add_vhost 'policykit-vhost'
+    sudo rabbitmqctl set_permissions -p 'policykit-vhost' 'username'.*' '.*' '.*'
 
 In ``policykit/settings.py``, set the ``CELERY_BROKER_URL`` as follows, substituting values for your RabbitMQ username, password, and virtual host:
 
 .. code-block:: python
 
-    CELERY_BROKER_URL = "amqp://USERNAME:PASSWORD@localhost:5672/VIRTUALHOST"
+    CELERY_BROKER_URL = "amqp://USERNAME:PASSWORD@localhost:5672/CUSTOMVIRTUALHOST"
 
 Create celery user
 """"""""""""""""""

--- a/docs/source/gettingstarted.rst
+++ b/docs/source/gettingstarted.rst
@@ -230,7 +230,7 @@ Install RabbitMQ and create a virtual host:
 
     sudo rabbitmqctl add_user 'username' 'password'
     sudo rabbitmqctl add_vhost 'policykit-vhost'
-    sudo rabbitmqctl set_permissions -p 'policykit-vhost' 'username'.*' '.*' '.*'
+    sudo rabbitmqctl set_permissions -p 'policykit-vhost' 'username' '.*' '.*' '.*'
 
 In ``policykit/settings.py``, set the ``CELERY_BROKER_URL`` as follows, substituting values for your RabbitMQ username, password, and virtual host:
 

--- a/docs/source/integrations.rst
+++ b/docs/source/integrations.rst
@@ -61,7 +61,7 @@ On the login page, select "Sign in with Discourse". This will display a screen a
 Metagov
 ~~~~~~~
 
-PolicyKit integrates with `Metagov <http://docs.metagov.org/>`_ to support policies that use of the `Metagov API <https://prototype.metagov.org/redoc/>`_ to use and govern a range of external platforms and governance tools such as Slack, Loomio, and SourceCred.
+PolicyKit integrates with `Metagov <http://docs.metagov.org/>`_ to support policies that use of the `Metagov API <https://metagov.policykit.org/redoc/>`_ to use and govern a range of external platforms and governance tools such as Slack, Loomio, and SourceCred.
 
 Configuring Metagov
 """""""""""""""""""
@@ -91,7 +91,7 @@ Metagov actions
 """"""""""""""""""""""""""
 
 Platform policies have access to a ``metagov`` client that can be used to invoke Metagov ``/action`` and ``/process`` endpoints.
-Refer to the `Metagov API docs <https://prototype.metagov.org/redoc/>`_ to see which actions and processes are available to you.
+Refer to the `Metagov API docs <https://metagov.policykit.org/redoc/>`_ to see which actions and processes are available to you.
 Policy authors can only use actions that are defined in plugins that are *currently enabled* in their community.
 See the :doc:`Sample Policies <../sample_policies>` for more examples.
 

--- a/docs/source/sample_policies.rst
+++ b/docs/source/sample_policies.rst
@@ -423,7 +423,7 @@ Add a NEAR DAO proposal
 -----------------------
 
 When a new Discourse topic is created with tag ``dao-proposal``, add a new proposal to the community's NEAR DAO.
-Uses the `near.call <https://prototype.metagov.org/redoc/#operation/near.call>`_ action.
+Uses the `near.call <https://metagov.policykit.org/redoc/#operation/near.call>`_ action.
 
 **Required Metagov Plugins**: ``discourse`` ``near``
 


### PR DESCRIPTION
`Require local` doesn't work in Apache 2.4, we need to specify the IP address instead. Also adds vhost instructions, since the  link is broken now.