### PR TITLE
Use Metagov slack.emoji-vote for boolean PlatformAction votes and elections

### DIFF
--- a/policykit/policyengine/models.py
+++ b/policykit/policyengine/models.py
@@ -578,7 +578,7 @@ class ConstitutionActionBundle(BaseAction):
     def save(self, *args, **kwargs):
         if not self.pk:
             action = self
-            if action.initiator.has_perm(action._meta.app_label + '.add_' + action.action_codename):
+            if action.initiator.has_perm(action._meta.app_label + '.add_' + action._meta.verbose_name):
                 govern_action(action, is_first_evaluation=True)
 
         super(ConstitutionActionBundle, self).save(*args, **kwargs)
@@ -1120,7 +1120,7 @@ class PlatformActionBundle(BaseAction):
     def save(self, *args, **kwargs):
         if not self.pk:
             action = self
-            if action.initiator.has_perm(action._meta.app_label + '.add_' + action.action_codename):
+            if action.initiator.has_perm(action._meta.app_label + '.add_' + action._meta.verbose_name):
                 govern_action(action, is_first_evaluation=True)
 
         super(PlatformActionBundle, self).save(*args, **kwargs)


### PR DESCRIPTION
Use the [slack.emoji-vote](https://prototype.metagov.org/redoc/#operation/Start%20slack.emoji-vote) metagov governance process to administer two kinds of votes: (1) Boolean votes on PlatformActions, and (2) Choice votes on PlatformActionBundle elections. Slack election voting was broken before, this fixes it.

![Screen Shot 2021-06-25 at 15 30 55](https://user-images.githubusercontent.com/5333982/123476215-66d0c480-d5ca-11eb-8ca5-0dba51d31d8e.png)
![Screen Shot 2021-06-25 at 15 30 48](https://user-images.githubusercontent.com/5333982/123476218-67695b00-d5ca-11eb-9b49-ac997b3f805c.png)


Follow-ups:
- Support ConstitutionActions https://github.com/amyxzhang/policykit/issues/412
- Handle closing processes so we don't have dangling pending processes in metagov