### PR TITLE
Add dummy GitHub action workflow file

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -1,0 +1,28 @@
+# This workflow will install Python dependencies, run tests and lint with a single version of Python
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
+
+
+name: PolicyKit Django application
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python 3.9
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.9
+    - name: Install dependencies
+      working-directory: ./policykit
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt


### PR DESCRIPTION
Add a workflow for running tests on CI. Currently it just installs dependencies. I need this workflow to exist on the default branch in order to test it on my branch (where I'm working on running integration tests with Metagov + PolicyKit)