### PR TITLE
Only set is_community_admin for users who INSTALLED PolicyKit to Slack

### DIFF
--- a/policykit/integrations/slack/models.py
+++ b/policykit/integrations/slack/models.py
@@ -5,7 +5,7 @@ import requests
 from django.conf import settings
 from django.contrib.auth.models import Permission
 from django.db import models
-from integrations.slack.utils import get_admin_user_token, reaction_to_boolean
+from integrations.slack.utils import get_admin_user_token
 from policyengine.models import (
     BooleanVote,
     CommunityPlatform,

--- a/policykit/integrations/slack/utils.py
+++ b/policykit/integrations/slack/utils.py
@@ -7,7 +7,6 @@ def get_slack_user_fields(user_info):
     return {
         "username": user_info["id"],
         "readable_name": user_info["profile"]["real_name"],
-        "is_community_admin": user_info["is_admin"] and not user_info["is_bot"],
         "avatar": user_info["profile"]["image_24"],
     }
 

--- a/policykit/integrations/slack/utils.py
+++ b/policykit/integrations/slack/utils.py
@@ -20,11 +20,3 @@ def get_admin_user_token(platform_community):
     if admin_user:
         return admin_user.access_token
     return None
-
-
-def reaction_to_boolean(reaction: str):
-    if reaction == "+1" or reaction.startswith("+1::skin-tone-"):
-        return True
-    if reaction == "-1" or reaction.startswith("-1::skin-tone-"):
-        return False
-    return None

--- a/policykit/integrations/slack/views.py
+++ b/policykit/integrations/slack/views.py
@@ -105,11 +105,12 @@ def slack_install(request):
                     username=new_user["id"],
                     readable_name=new_user["real_name"],
                     avatar=new_user["profile"]["image_24"],
-                    is_community_admin=new_user["is_admin"],
                     community=slack_community,
                 )
                 if user_token and user_id and new_user["id"] == user_id:
                     logger.debug(f"Storing access_token for installing user ({user_id})")
+                    # Installer has is_community_admin because they are an admin in Slack, AND we requested special user scoped from them
+                    u.is_community_admin = True
                     u.access_token = user_token
                     u.save()
 
@@ -133,6 +134,8 @@ def slack_install(request):
             installer = SlackUser.objects.filter(community=slack_community, username=user_id).first()
             if installer is not None:
                 logger.debug(f"Storing access_token for installing user ({user_id})")
+                # Installer has is_community_admin because they are an admin in Slack, AND we requested special user scoped from them
+                installer.is_community_admin = True
                 installer.access_token = user_token
                 installer.save()
             else:
@@ -140,7 +143,7 @@ def slack_install(request):
                 response = slack_community.make_call("users.info", {"user": user_id})
                 user_info = response["user"]
                 user_fields = get_slack_user_fields(user_info)
-                user_fields["password"] = user_token
+                user_fields["is_community_admin"] = True
                 user_fields["access_token"] = user_token
                 SlackUser.objects.create(
                     community=slack_community,
@@ -290,4 +293,6 @@ def post_policy(policy, action, users=[], post_type="channel", template=None, ch
     ts = process["outcome"]["message_ts"]
     action.community_post = ts
     action.save()
-    logger.debug(f"Saved action with '{ts}' as community_post, and process at {action.proposal.governance_process_url}")
+    logger.debug(
+        f"Saved action with '{ts}' as community_post, and process at {action.proposal.governance_process_url}"
+    )

--- a/policykit/integrations/slack/views.py
+++ b/policykit/integrations/slack/views.py
@@ -109,7 +109,7 @@ def slack_install(request):
                 )
                 if user_token and user_id and new_user["id"] == user_id:
                     logger.debug(f"Storing access_token for installing user ({user_id})")
-                    # Installer has is_community_admin because they are an admin in Slack, AND we requested special user scoped from them
+                    # Installer has is_community_admin because they are an admin in Slack, AND we requested special user scopes from them
                     u.is_community_admin = True
                     u.access_token = user_token
                     u.save()
@@ -134,7 +134,7 @@ def slack_install(request):
             installer = SlackUser.objects.filter(community=slack_community, username=user_id).first()
             if installer is not None:
                 logger.debug(f"Storing access_token for installing user ({user_id})")
-                # Installer has is_community_admin because they are an admin in Slack, AND we requested special user scoped from them
+                # Installer has is_community_admin because they are an admin in Slack, AND we requested special user scopes from them
                 installer.is_community_admin = True
                 installer.access_token = user_token
                 installer.save()


### PR DESCRIPTION
`is_community_admin` is used for Slack to determine which user has a specially privileged access token with certain user scopes that are needed for some actions (like `chat.delete`). Only the installing user(s) have these tokens, because we request access to those user scopes during installation.

This `get_admin_user_token` was mistakenly returning tokens for users who ARE admins in Slack, but who have not authorized all the necessary scopes to act as an admin through the metagov/policykit slack app.

https://github.com/amyxzhang/policykit/blob/04dec04458df7c54343556e28315f35495a16e58/policykit/integrations/slack/utils.py#L15-L23