### PR TITLE
Add django_extensions to get shell_plus and other command extensions

### DIFF
--- a/docs/source/gettingstarted.rst
+++ b/docs/source/gettingstarted.rst
@@ -50,7 +50,7 @@ Getting Started
 
 ::
 
- python manage.py shell
+ python manage.py shell_plus
 
 From the shell prompt, run the following command to create the starterkits:
 

--- a/policykit/policykit/settings.py
+++ b/policykit/policykit/settings.py
@@ -30,14 +30,7 @@ SECRET_KEY = 'kg=&9zrc5@rern2=&+6yvh8ip0u7$f=k_zax**bwsur_z7qy+-'
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-ALLOWED_HOSTS = ['policykit.org',
-                 'www.policykit.org',
-                 'ec2-52-41-245-161.us-west-2.compute.amazonaws.com',
-                 '52.41.245.161',
-                 '127.0.0.1',
-                 'ec2-54-190-197-117.us-west-2.compute.amazonaws.com',
-                 '54.190.197.117',
-                 'localhost']
+ALLOWED_HOSTS = ['127.0.0.1']
 
 # Let environment variables override private.py, for testing
 if os.environ.get("METAGOV_URL"):
@@ -229,8 +222,6 @@ LOGGING = {
     },
     'loggers': loggers
 }
-
-from celery.schedules import crontab
 
 # Replace with "amqp://USERNAME:PASSWORD@localhost:5672/VIRTUALHOST"
 CELERY_BROKER_URL = 'amqp://'

--- a/policykit/policykit/settings.py
+++ b/policykit/policykit/settings.py
@@ -72,6 +72,7 @@ INSTALLED_APPS = [
     'django_celery_results',
     'django_filters',
     'django_tables2',
+    'django_extensions',
     'django_db_logger',
     'actstream',
     'policyengine',

--- a/policykit/requirements.txt
+++ b/policykit/requirements.txt
@@ -19,6 +19,7 @@ Django==3.2.2
 django-activity-stream==0.10.0
 django-celery-beat==2.2.0
 django-celery-results==2.0.1
+django-extensions==3.1.3
 django-filter==2.4.0
 django-grappelli==2.15.1
 django-jet==1.0.8
@@ -79,6 +80,7 @@ typing-extensions==3.7.4.3
 urllib3==1.25.8
 vine==1.3.0
 wcwidth==0.1.8
+websocket==0.2.1
 websocket-client==0.58.0
 wrapt==1.12.1
 zipp==2.0.1


### PR DESCRIPTION
Adding [shell_plus](https://django-extensions.readthedocs.io/en/latest/shell_plus.html) which is nice because it automatically imports everything. Metagov uses it too, so this makes the debugging experience more consistent across them. Launch with `python manage.py shell_plus`.