### PR TITLE
Skip policies that raise exceptions

### DIFF
--- a/policykit/policyengine/views.py
+++ b/policykit/policyengine/views.py
@@ -8,8 +8,6 @@ from actstream.models import Action
 from policyengine.filter import *
 from policykit.settings import SERVER_URL, METAGOV_ENABLED
 import integrations.metagov.api as MetagovAPI
-from pylint.lint import Run
-from pylint.reporters.text import TextReporter
 from django.conf import settings
 from urllib.parse import quote
 import integrations.metagov.api as MetagovAPI


### PR DESCRIPTION
The policy author can review the error on the Logs page. This protects against situations where a policy consistently raises an exception, so the PlatformAction gets stuck in `proposed` state and we just try again and again to execute the same failing policy.