### PR TITLE
Allow proposing any PlatformAction in the PolicyKit UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 docs/build
 .DS_Store
+.vscode

--- a/policykit/integrations/discord/views.py
+++ b/policykit/integrations/discord/views.py
@@ -339,7 +339,8 @@ def connect_gateway():
     wst.daemon = True
     wst.start()
 
-connect_gateway()
+if DISCORD_CLIENT_ID:
+    connect_gateway()
 
 def oauth(request):
     state = request.GET.get('state')

--- a/policykit/integrations/slack/models.py
+++ b/policykit/integrations/slack/models.py
@@ -126,8 +126,6 @@ class SlackCommunity(CommunityPlatform):
             elif obj.AUTH == "admin_user":
                 data["token"] = admin_user_token
 
-            if data["token"] is None:
-                data.pop("token")  # remove token override if we don't have one
             logger.debug(f"Overriding token? {True if data.get('token') else False}")
 
             try:
@@ -271,7 +269,8 @@ class SlackCommunity(CommunityPlatform):
 
     def __make_generic_api_call(self, method: str, values):
         """Make any Slack method request using Metagov action 'slack.method' """
-        return LogAPICall.make_api_call(self, {"method_name": method, **values}, "slack.method")
+        cleaned = {k: v for k, v in values.items() if v is not None} if values else {}
+        return LogAPICall.make_api_call(self, {"method_name": method, **cleaned}, "slack.method")
 
 
 class SlackPostMessage(PlatformAction):

--- a/policykit/policyengine/models.py
+++ b/policykit/policyengine/models.py
@@ -3,6 +3,7 @@ from actstream import action
 import requests
 from django.contrib.auth.models import UserManager, User, Group, Permission
 from django.contrib.contenttypes.models import ContentType
+from django.forms import ModelForm
 from django.conf import settings
 from django.db.models.signals import post_delete
 from django.dispatch import receiver
@@ -1288,3 +1289,21 @@ class NumberVote(UserVote):
 
     def __str__(self):
         return str(self.user) + ' : ' + str(self.number_value)
+
+class PlatformActionForm(ModelForm):
+    class Meta:
+        model = PlatformAction
+        exclude = [
+            "initiator",
+            "community",
+            "community_revert",
+            "community_origin",
+            "is_bundled",
+            "community_post",
+            "proposal",
+            "data"
+        ]
+
+    def __init__(self, *args, **kwargs):
+        super(PlatformActionForm, self).__init__(*args, **kwargs)
+        self.label_suffix = ''

--- a/policykit/policyengine/utils.py
+++ b/policykit/policyengine/utils.py
@@ -1,0 +1,24 @@
+from django.apps import apps
+
+def find_action_cls(app_name: str, action_codename: str):
+    """
+    Get the PlatformAction subclass that has the specified codename
+    """
+    from policyengine.models import PlatformAction
+    for cls in apps.get_app_config(app_name).get_models():
+        if issubclass(cls, PlatformAction) and hasattr(cls, "action_codename"):
+            if action_codename == getattr(cls, "action_codename"):
+                return cls
+    return None
+
+def get_action_codenames(app_name: str):
+    """
+    Get a list of action_codenames for PlatformAction models defined in the given app
+    """
+    from policyengine.models import PlatformAction
+    action_list = []
+    for cls in apps.get_app_config(app_name).get_models():
+            if issubclass(cls, PlatformAction) and hasattr(cls, "action_codename"):
+                codename = getattr(cls, "action_codename")
+                action_list.append(codename)
+    return action_list

--- a/policykit/policyengine/views.py
+++ b/policykit/policyengine/views.py
@@ -5,12 +5,14 @@ from django.contrib.auth.models import Permission
 from django.http import HttpResponse, JsonResponse, HttpResponseBadRequest, HttpResponseRedirect
 from django.views.decorators.csrf import csrf_exempt
 from django.shortcuts import render, redirect
+from django.forms import modelform_factory
+from django.apps import apps
 from actstream.models import Action
-from policyengine.filter import *
+from policyengine.filter import filter_code
 from policyengine.linter import _error_check
+from policyengine.utils import find_action_cls, get_action_codenames
 from policykit.settings import SERVER_URL, METAGOV_ENABLED
 import integrations.metagov.api as MetagovAPI
-import urllib.parse
 from urllib.parse import quote
 import random
 import logging
@@ -337,11 +339,49 @@ def documenteditor(request):
 @login_required(login_url='/login')
 def actions(request):
     user = get_user(request)
-
+    app_names = [user.community.platform] # TODO: show actions for other connected platforms
+    actions = [(app_name, get_action_codenames(app_name)) for app_name in app_names]
     return render(request, 'policyadmin/dashboard/actions.html', {
         'server_url': SERVER_URL,
         'user': get_user(request),
+        'actions': actions
     })
+
+@login_required(login_url='/login')
+def propose_action(request, app_name, codename):
+    cls = find_action_cls(app_name, codename)
+    if not cls:
+        return HttpResponseBadRequest()
+
+    from policyengine.models import PlatformActionForm
+
+    ActionForm = modelform_factory(
+        cls,
+        form=PlatformActionForm,
+        fields=getattr(cls, "EXECUTE_PARAMETERS", "__all__"),
+        localized_fields="__all__"
+    )
+
+    if request.method == 'POST':
+        form = ActionForm(request.POST, request.FILES)
+        if form.is_valid():
+            new_action = form.save(commit=False)
+            new_action.initiator = request.user
+            new_action.community = request.user.community
+            new_action.save()
+    else:
+        form = ActionForm()
+    return render(
+        request,
+        "policyadmin/dashboard/action_proposer.html",
+        {
+            "server_url": SERVER_URL,
+            "user": get_user(request),
+            "form": form,
+            "app_name": app_name,
+            "codename": codename
+        },
+    )
 
 def evaluation_logger(policy, action, level="DEBUG"):
     """
@@ -788,7 +828,7 @@ def _execute_policy(policy, action, is_first_evaluation: bool):
     if not filter_result:
         return False
 
-    from policyengine.models import Proposal
+    from policyengine.models import Proposal, ConstitutionAction, PlatformAction
 
     optional_args = {}
     if METAGOV_ENABLED:
@@ -814,12 +854,20 @@ def _execute_policy(policy, action, is_first_evaluation: bool):
         action.pass_action()
         assert action.proposal.status == Proposal.PASSED
 
+        # EXECUTE the action if....
+        # it is a PlatformAction that was proposed in the PolicyKit UI
+        if issubclass(action, PlatformAction) and not action.community_origin:
+            action.execute()
+        # it is a constitution action
+        elif issubclass(action, ConstitutionAction):
+            action.execute()
+
         if METAGOV_ENABLED:
             # Close pending process if exists (does nothing if process was already closed)
             optional_args["metagov"].close_process()
             action.proposal.close_governance_process()
 
-    elif check_result == Proposal.FAILED:
+    if check_result == Proposal.FAILED:
         # run "fail" block of policy
         fail_policy(policy, action, **optional_args)
         debug(f"Executed fail block of policy")
@@ -832,20 +880,16 @@ def _execute_policy(policy, action, is_first_evaluation: bool):
             optional_args["metagov"].close_process()
             action.proposal.close_governance_process()
 
-        # If this is the first time evaluating, and it originated in a community, revert it
-        if is_first_evaluation and action.community_origin:
-            action.revert()
+    # Revert the action if necessary
+    should_revert = is_first_evaluation and check_result in [Proposal.PROPOSED, Proposal.FAILED] and issubclass(action, PlatformAction) and action.community_origin
+    if should_revert:
+        debug(f"Reverting")
+        action.revert()
 
-    elif check_result == Proposal.PROPOSED and is_first_evaluation:
-        # Revert if this action originated in the community (ie it was not proposed manually in the PK UI)
-        if hasattr(action, 'community_origin'):
-            debug(f"Reverting")
-            action.revert()
+    # If this action is moving into pending state for the first time, run the Notify block (to start a vote, maybe)
+    if check_result == Proposal.PROPOSED and is_first_evaluation:
         # Run "notify" block of policy
         debug(f"Notifying")
         notify_policy(policy, action, **optional_args)
-    else:
-        # do nothing, it's still pending
-        pass
 
     return True

--- a/policykit/policyengine/views.py
+++ b/policykit/policyengine/views.py
@@ -858,10 +858,10 @@ def _execute_policy(policy, action, is_first_evaluation: bool):
 
         # EXECUTE the action if....
         # it is a PlatformAction that was proposed in the PolicyKit UI
-        if issubclass(action, PlatformAction) and not action.community_origin:
+        if issubclass(type(action), PlatformAction) and not action.community_origin:
             action.execute()
         # it is a constitution action
-        elif issubclass(action, ConstitutionAction):
+        elif issubclass(type(action), ConstitutionAction):
             action.execute()
 
         if METAGOV_ENABLED:
@@ -883,7 +883,11 @@ def _execute_policy(policy, action, is_first_evaluation: bool):
             action.proposal.close_governance_process()
 
     # Revert the action if necessary
-    should_revert = is_first_evaluation and check_result in [Proposal.PROPOSED, Proposal.FAILED] and issubclass(action, PlatformAction) and action.community_origin
+    should_revert = is_first_evaluation and \
+        check_result in [Proposal.PROPOSED, Proposal.FAILED] and \
+        issubclass(type(action), PlatformAction) and \
+        action.community_origin
+
     if should_revert:
         debug(f"Reverting")
         action.revert()

--- a/policykit/policyengine/views.py
+++ b/policykit/policyengine/views.py
@@ -362,13 +362,19 @@ def propose_action(request, app_name, codename):
         localized_fields="__all__"
     )
 
+    error = None
     if request.method == 'POST':
         form = ActionForm(request.POST, request.FILES)
         if form.is_valid():
             new_action = form.save(commit=False)
             new_action.initiator = request.user
             new_action.community = request.user.community
-            new_action.save()
+            try:
+                new_action.save()
+            except Exception as e:
+                logger.error(f"Error saving proposed action: {e}")
+                error = str(e) # display error to the user, for now
+                new_action.delete()
     else:
         form = ActionForm()
     return render(
@@ -379,7 +385,8 @@ def propose_action(request, app_name, codename):
             "user": get_user(request),
             "form": form,
             "app_name": app_name,
-            "codename": codename
+            "codename": codename,
+            "error": error
         },
     )
 

--- a/policykit/policyengine/views.py
+++ b/policykit/policyengine/views.py
@@ -362,6 +362,7 @@ def propose_action(request, app_name, codename):
         localized_fields="__all__"
     )
 
+    new_action = None
     if request.method == 'POST':
         form = ActionForm(request.POST, request.FILES)
         if form.is_valid():

--- a/policykit/policyengine/views.py
+++ b/policykit/policyengine/views.py
@@ -362,19 +362,13 @@ def propose_action(request, app_name, codename):
         localized_fields="__all__"
     )
 
-    error = None
     if request.method == 'POST':
         form = ActionForm(request.POST, request.FILES)
         if form.is_valid():
             new_action = form.save(commit=False)
             new_action.initiator = request.user
             new_action.community = request.user.community
-            try:
-                new_action.save()
-            except Exception as e:
-                logger.error(f"Error saving proposed action: {e}")
-                error = str(e) # display error to the user, for now
-                new_action.delete()
+            new_action.save()
     else:
         form = ActionForm()
     return render(
@@ -386,7 +380,7 @@ def propose_action(request, app_name, codename):
             "form": form,
             "app_name": app_name,
             "codename": codename,
-            "error": error
+            "action": new_action
         },
     )
 

--- a/policykit/policykit/urls.py
+++ b/policykit/policykit/urls.py
@@ -29,7 +29,7 @@ urlpatterns = [
     path('main/documenteditor/', policyviews.documenteditor),
     path('main/selectdocument/', policyviews.selectdocument),
     path('main/actions/', policyviews.actions),
-    path('main/actions/<str:app_name>/<str:codename>', policyviews.propose_action, name="propose_action_form"),
+    path('main/actions/<str:app_name>/<str:codename>', policyviews.propose_action),
     path('main/policyengine/', include('policyengine.urls')),
     path('main/settings/', policyviews.settings_page, name="settings"),
     path('main/logs/', include('django_db_logger.urls', namespace='django_db_logger')),

--- a/policykit/policykit/urls.py
+++ b/policykit/policykit/urls.py
@@ -29,6 +29,7 @@ urlpatterns = [
     path('main/documenteditor/', policyviews.documenteditor),
     path('main/selectdocument/', policyviews.selectdocument),
     path('main/actions/', policyviews.actions),
+    path('main/actions/<str:app_name>/<str:codename>', policyviews.propose_action, name="propose_action_form"),
     path('main/policyengine/', include('policyengine.urls')),
     path('main/settings/', policyviews.settings_page, name="settings"),
     path('main/logs/', include('django_db_logger.urls', namespace='django_db_logger')),

--- a/policykit/scripts/starterkits.py
+++ b/policykit/scripts/starterkits.py
@@ -6,7 +6,6 @@ from integrations.discourse.models import DiscourseStarterKit
 from integrations.reddit.models import RedditStarterKit
 from integrations.slack.models import SlackStarterKit
 from policyengine.models import *
-from polymorphic.models import PolymorphicModel
 
 # default starterkit -- all users have ability to view/propose actions + all constitution actions execute automatically
 testing_starterkit_slack = SlackStarterKit(name="Testing Starter Kit", platform="slack")
@@ -30,17 +29,9 @@ all_actions_pass = {
     "fail": "pass",
 }
 
-all_actions_execute = {
-    "filter": "return True",
-    "initialize": "pass",
-    "check": "return PASSED",
-    "notify": "pass",
-    "success": "action.execute()",
-    "fail": "pass",
-}
 
 testing_policy1_slack = GenericPolicy.objects.create(
-    **all_actions_execute,
+    **all_actions_pass,
     description="Starter Constitution Policy: all constitution actions execute automatically",
     name="All Constitution Actions Pass",
     starterkit=testing_starterkit_slack,
@@ -58,7 +49,7 @@ testing_policy2_slack = GenericPolicy.objects.create(
 )
 
 testing_policy1_reddit = GenericPolicy.objects.create(
-    **all_actions_execute,
+    **all_actions_pass,
     description="Starter Constitution Policy: all constitution actions execute automatically",
     name="All Constitution Actions Pass",
     starterkit=testing_starterkit_reddit,
@@ -76,7 +67,7 @@ testing_policy2_reddit = GenericPolicy.objects.create(
 )
 
 testing_policy1_discord = GenericPolicy.objects.create(
-    **all_actions_execute,
+    **all_actions_pass,
     description="Starter Constitution Policy: all constitution actions execute automatically",
     name="All Constitution Actions Pass",
     starterkit=testing_starterkit_discord,
@@ -94,7 +85,7 @@ testing_policy2_discord = GenericPolicy.objects.create(
 )
 
 testing_policy1_discourse = GenericPolicy.objects.create(
-    **all_actions_execute,
+    **all_actions_pass,
     description="Starter Constitution Policy: all constitution actions execute automatically",
     name="All Constitution Actions Pass",
     starterkit=testing_starterkit_discourse,

--- a/policykit/templates/policyadmin/dashboard/action_proposer.html
+++ b/policykit/templates/policyadmin/dashboard/action_proposer.html
@@ -41,6 +41,12 @@
     background-color: #3b4699;
     color: #ffffff;
   }
+  .alert {
+    font-family: 'Nunito', sans-serif;
+    font-size: 1.2em;
+    color: red;
+    margin-top: 1em;
+  }
 </style>
 {% endblock %}
 
@@ -62,6 +68,9 @@
           {{ form.as_table }}
         </table>
         <input type="submit" class="btn" value="Propose action">
+        {% if error %}
+          <div class="alert">{{ error }}</div>
+        {% endif %}
       </form>
     </div>
   </div>

--- a/policykit/templates/policyadmin/dashboard/action_proposer.html
+++ b/policykit/templates/policyadmin/dashboard/action_proposer.html
@@ -68,7 +68,13 @@
         </table>
         <input type="submit" class="btn" value="Propose action">
         {% if action and action.proposal.status is not None %}
-          <div class="alert">Action was {{ action.proposal.status }}.</div>
+          {% if action.proposal.status == "failed" %}
+            <div class="alert">Action failed. See logs for more information.</div>
+          {% elif action.proposal.status == "proposed" %}
+            <div class="alert">Action proposed.</div>
+          {% elif action.proposal.status == "passed" %}
+            <div class="alert">Action passed!</div>
+          {% endif %}
         {% endif %}
       </form>
     </div>

--- a/policykit/templates/policyadmin/dashboard/action_proposer.html
+++ b/policykit/templates/policyadmin/dashboard/action_proposer.html
@@ -1,0 +1,70 @@
+{% extends "./dashboard_base.html" %}
+{% load static %}
+
+{% block styles %}
+<style>
+  .body {
+    display: flex;
+    flex-direction: column;
+  }
+
+  .headerText {
+    font-family: 'Nunito', sans-serif;
+    font-size: 2em;
+  }
+  table {
+    margin-top: 2em;
+    margin-bottom: 2em;
+  }
+  th {
+    padding-right: 1em;
+    font-family: 'Nunito', sans-serif;
+    font-size: 1.2em;
+  }
+  th label {
+    margin: 0;
+  }
+  td {
+    padding-top: 1em;
+    padding-bottom: 1em;
+  }
+
+  .btn {
+    padding: 0.5em 2vw;
+    font-family: 'Nunito', sans-serif;
+    font-size: 1.2em;
+    background-color: #4451b2;
+    color: #ffffff;
+  }
+
+  .btn:hover {
+    background-color: #3b4699;
+    color: #ffffff;
+  }
+</style>
+{% endblock %}
+
+{% block content %}
+<div class="body">
+  <div class="form-row">
+    <div class="col-sm-1"></div>
+    <div class="col-sm-11">
+      <h3 class="headerText">Propose {{codename}}</h3>
+    </div>
+  </div>
+
+  <div class="form-row">
+    <div class="col-sm-1"></div>
+    <div class="col-sm-11">
+      <form action="/main/actions/{{app_name}}/{{codename}}" method="post">
+        {% csrf_token %}
+        <table>
+          {{ form.as_table }}
+        </table>
+        <input type="submit" class="btn" value="Propose action">
+      </form>
+    </div>
+  </div>
+
+</div>
+{% endblock %}

--- a/policykit/templates/policyadmin/dashboard/action_proposer.html
+++ b/policykit/templates/policyadmin/dashboard/action_proposer.html
@@ -44,7 +44,6 @@
   .alert {
     font-family: 'Nunito', sans-serif;
     font-size: 1.2em;
-    color: red;
     margin-top: 1em;
   }
 </style>
@@ -68,8 +67,8 @@
           {{ form.as_table }}
         </table>
         <input type="submit" class="btn" value="Propose action">
-        {% if error %}
-          <div class="alert">{{ error }}</div>
+        {% if action and action.proposal.status is not None %}
+          <div class="alert">Action was {{ action.proposal.status }}.</div>
         {% endif %}
       </form>
     </div>

--- a/policykit/templates/policyadmin/dashboard/actions.html
+++ b/policykit/templates/policyadmin/dashboard/actions.html
@@ -123,8 +123,8 @@
           <table class="table table-hover">
             <tbody>
               {% for codename in action_list %}
-                <tr class="actionItem">
-                  <td><a href="{% url 'propose_action_form' app_name=app_name codename=codename %}">Propose {{codename}}</a></td>
+                <tr class="actionItem" onclick="proposePlatformActionLink('{{ app_name }}', '{{ codename }}')">
+                  <td>Propose {{codename}}</td>
                 </tr>
               {% endfor %}
             </tbody>
@@ -207,6 +207,10 @@
   document.getElementById("editDocument").addEventListener("click", function(){ navDocumentSelect('Change'); });
   document.getElementById("removeDocument").addEventListener("click", function(){ navDocumentSelect('Remove'); });
   document.getElementById("recoverDocument").addEventListener("click", function(){ navDocumentSelect('Recover'); });
+
+  function proposePlatformActionLink(app_name, action_codename) {
+    window.location.href = `{{server_url}}/main/actions/${app_name}/${action_codename}`
+  }
 
   function navEditor(type, operation) {
     window.location.href = `{{server_url}}/main/editor?type=${type}&operation=${operation}`

--- a/policykit/templates/policyadmin/dashboard/actions.html
+++ b/policykit/templates/policyadmin/dashboard/actions.html
@@ -38,6 +38,9 @@
     font-size: 1.5em;
     padding: 1em 0 0.5em 2vw;
   }
+  .actionPanelTitle:first-letter {
+    text-transform: capitalize;
+  }
 
   .actionPanelContent {
     width: 92%;
@@ -50,6 +53,12 @@
     font-size: 1em;
     cursor: pointer;
   }
+  .actionItem td a {
+    color: unset;
+  }
+  .actionItem td a:hover {
+    text-decoration: unset;
+  }
 
   .actionItem:hover {
     color: #808b96;
@@ -60,61 +69,6 @@
 {% block content %}
 <h2 class="actionScreenHeader">Which action would you like to propose?</h2>
 <div class="actionsContainer">
-  <!--{% if user.community.platform == "slack" %}
-    <div class="actionMenu" id="slackActionsHeader">
-      <h3 class="actionMenuHeading">Slack actions</h3>
-    </div>
-    <div class="actionContent" id="slackActions">
-      <div class="actionButton">
-        <p>Join conversation</p>
-      </div>
-      <div class="actionButton">
-        <p>Kick from conversation</p>
-      </div>
-      <div class="actionButton">
-        <p>Pin message</p>
-      </div>
-      <div class="actionButton">
-        <p>Post message</p>
-      </div>
-      <div class="actionButton">
-        <p>Rename conversation</p>
-      </div>
-      <div class="actionButton">
-        <p>Schedule message</p>
-      </div>
-    </div>
-  {% elif user.community.platform == "reddit" %}
-    <div class="actionMenu" id="redditActionsHeader">
-      <h3 class="actionMenuHeading">Reddit actions</h3>
-    </div>
-    <div class="actionContent" id="redditActions">
-    </div>
-  {% elif user.community.platform == "discord" %}
-    <div class="actionMenu" id="discordActionsHeader">
-      <h3 class="actionMenuHeading">Discord actions</h3>
-    </div>
-    <div class="actionContent" id="discordActions">
-      <div class="actionButton">
-        <p>Post message</p>
-      </div>
-      <div class="actionButton">
-        <p>Rename channel</p>
-      </div>
-    </div>
-  {% elif user.community.platform == "discourse" %}
-    <div class="actionMenu" id="discourseActionsHeader">
-      <h3 class="actionMenuHeading">Discourse actions</h3>
-    </div>
-    <div class="actionContent" id="discourseActions">
-      <div class="actionButton">
-        <p>Create topic</p>
-      </div>
-      <div class="actionButton">
-        <p>Create post</p>
-      </div>
-    </div>
-  {% endif %}-->
 
   <div class="actionsCol">
 
@@ -161,6 +115,23 @@
         </table>
       </div>
     </div>
+
+    {% for app_name, action_list in actions %}
+      <div class="actionPanel">
+        <h4 class="actionPanelTitle">{{app_name}} platform actions</h4>
+        <div class="actionPanelContent">
+          <table class="table table-hover">
+            <tbody>
+              {% for codename in action_list %}
+                <tr class="actionItem">
+                  <td><a href="{% url 'propose_action_form' app_name=app_name codename=codename %}">Propose {{codename}}</a></td>
+                </tr>
+              {% endfor %}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    {% endfor %}
 
   </div>
 

--- a/policykit/tests/test_metagov_integration.py
+++ b/policykit/tests/test_metagov_integration.py
@@ -87,6 +87,7 @@ return FAILED
         action = SlackPinMessage()
         action.initiator = self.user
         action.community = self.slack_community
+        action.community_origin = True
 
         # 2) Save action to trigger policy execution
         action.save()
@@ -121,6 +122,7 @@ return FAILED"""
         action = SlackPinMessage()
         action.initiator = self.user
         action.community = self.slack_community
+        action.community_origin = True
         action.save()
 
         self.assertEqual(action.proposal.status, "passed")


### PR DESCRIPTION
* Implements the UI for proposing PlatformActions (Closes https://github.com/amyxzhang/policykit/issues/346)
* Changes the PolicyEngine evaluation loop so that....
  * When an action that was proposed in the UI passes (aka `community_origin == False`), the engine calls `action.execute()`.
     * Another way I could have implemented this is to modify the "pass" of All Actions Pass policy to be `if not action.community_origin: action.execute()`. That would also work and aligns with the goals of https://github.com/amyxzhang/policykit/issues/318, but I'd rather not mess with the StarterKit policies now and just continue as-is adding this logic to the engine. Then when we implement 318 we can lift this logic into policies (if we agree on that - want to confirm approach with @amyxzhang first as well). I think this approach will be less disruptive to current users.
  * When a constitution action passes, the engine executes it (@rickygv99 this removes the need for "all actions execute" fallback policy, which was removed. you may need to change that starter policy on your server.)


-----
screenshots

### All the available actions for the current platform are listed. The "action_codename" is used for now because we don't have readable names defined.
![Screen Shot 2021-07-12 at 12 09 59](https://user-images.githubusercontent.com/5333982/125321296-8bd37000-e30a-11eb-9759-8f2a8ee36540.png)

### The form is generated based on the model's fields. The choice of fields can be overridden on each model. For example, here we hide the "previous name" field because it's not necessary:
![Screen Shot 2021-07-12 at 12 10 34](https://user-images.githubusercontent.com/5333982/125321543-cc32ee00-e30a-11eb-83b9-6dffed4ea87c.png)

### If there are no overrides, all fields are shown (Excluding BaseAction and PlatformAction fields). For example:

![Screen Shot 2021-07-12 at 12 15 30](https://user-images.githubusercontent.com/5333982/125321786-0bf9d580-e30b-11eb-9002-e118187a754e.png)


### On submit, a message shows whether the action passed, failed, or was proposed.
 
![Screen Shot 2021-07-12 at 12 12 10](https://user-images.githubusercontent.com/5333982/125321912-29c73a80-e30b-11eb-9a9d-84c890e5de17.png)
![Screen Shot 2021-07-12 at 12 12 29](https://user-images.githubusercontent.com/5333982/125321922-2cc22b00-e30b-11eb-983d-34c0f22f2ac4.png)

