### PR TITLE
Rename community notify_action -> initiate_vote, add post_message, fix Slack bugs

### DIFF
--- a/docs/source/policy_model.rst
+++ b/docs/source/policy_model.rst
@@ -23,7 +23,7 @@ Check
 Notify
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-| If the policy involves reaching out to one or more community members for input, then the code for notifying members occurs in this function. While policy authors can send messages to users in any function, this function is specifically for notifications soliciting user input. Authors may use the helper method ``notify_action()`` to send messages to community members, with ability to customize the post. For instance, the notification post can include instructions, such as to deliberate the action before voting. This function is only run once, after a new action does not return ``PASSED`` or ``FAILED`` from the first ``check()``, so as to not unnecessarily notify users.
+| If the policy involves reaching out to one or more community members for input, then the code for notifying members occurs in this function. While policy authors can send messages to users in any function, this function is specifically for notifications soliciting user input. Authors may use the method ``initiate_vote()`` to start a vote on whether or not to pass the action. This function is only run once, after a new action does not return ``PASSED`` or ``FAILED`` from the first ``check()``, so as to not unnecessarily notify users.
 
 Pass
 ~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/sample_policies.rst
+++ b/docs/source/sample_policies.rst
@@ -39,39 +39,23 @@ Vote on renaming a channel
 
 .. code-block:: python
 
-  message = f"Should this channel be renamed from #{action.prev_name} to #{action.name}? Vote with :thumbsup: or :thumbsdown: on this post."
-  action.community.notify_action(action, policy, template=message)
+  message = f"Should this channel be renamed to #{action.name}? Vote with :thumbsup: or :thumbsdown: on this post."
+  action.community.initiate_vote(action, policy, template=message)
 
 **Pass:**
 
 .. code-block:: python
 
-  yes_votes = action.proposal.get_yes_votes().count()
-  no_votes = action.proposal.get_no_votes().count()
-
+  text = f"Proposal to rename this channel to #{action.name} passed."
+  action.community.post_message(text=text, channel=action.channel, thread_ts=action.community_post)
   action.execute()
-
-  message = f"Proposal to rename this channel to #{action.name} passed with {yes_votes} for and {no_votes} against. This action was governed by Policy: {policy.name}"
-  action.community.notify_action(
-      action,
-      policy,
-      users=[action.initiator],
-      template=message
-  )
 
 **Fail:**
 
 .. code-block:: python
 
-  yes_votes = action.proposal.get_yes_votes().count()
-  no_votes = action.proposal.get_no_votes().count()
-  message = f"Proposal to rename this channel to #{action.name} failed with {yes_votes} for and {no_votes} against. This action was governed by Policy: {policy.name}"
-  action.community.notify_action(
-      action,
-      policy,
-      users=[action.initiator],
-      template=message
-  )
+  text = f"Proposal to rename this channel to #{action.name} failed."
+  action.community.post_message(text=text, channel=action.channel, thread_ts=action.community_post)
 
 
 Don't allow posts in channel
@@ -100,9 +84,8 @@ Posts in the channel are auto-deleted, and the user is notified about why it hap
 
   # create an ephemeral post that is only visible to the poster
   message = f"Post was deleted because of policy '{policy.name}'"
-  action.community.notify_action(
-    action,
-    policy,
+  action.community.post_message(
+    channel=action.channel,
     users=[action.initiator],
     post_type="ephemeral",
     template=message
@@ -172,7 +155,7 @@ where num refers to a positive non-zero integer value. This command simulates ro
   if tokens[0] != "!roll":
     return False
   if len(tokens) < 2 or len(tokens) > 3:
-    action.community.notify_action(action, policy, users, template='not right number of tokens: should be 2 or 3', channel = "733209360549019688")
+    action.community.post_message(text='not right number of tokens: should be 2 or 3', channel = "733209360549019688")
     return False
   return True
 
@@ -184,20 +167,21 @@ where num refers to a positive non-zero integer value. This command simulates ro
 
   import random
   tokens = action.text.split()
+  channel = 733209360549019691
   if tokens[1][0] != "d":
-    action.community.notify_action(action, policy, users, template='not have d', channel = "733209360549019691")
+    action.community.post_message(text='not have d', channel=channel)
     return FAILED
   if tokens[1][1:].isnumeric() == False:
-    action.community.notify_action(action, policy, users, template='not numeric num faces', channel = "733209360549019691")
+    action.community.post_message(text='not numeric num faces', channel=channel)
     return FAILED
   num_faces = int(tokens[1][1:])
   num_modifier = 0
   if len(tokens) == 3:
     if tokens[2][0] != "+":
-      action.community.notify_action(action, policy, users, template='not have +', )
+      action.community.post_message(text='not have +', channel=channel)
       return FAILED
     if tokens[2][1:].isnumeric() == False:
-      action.community.notify_action(action, policy, users, template='not numeric num modifier')
+      action.community.post_message(text='not numeric num modifier', channel=channel)
       return FAILED
     num_modifier = int(tokens[2][1:])
   roll_unmodified = random.randint(1, num_faces)
@@ -213,14 +197,14 @@ where num refers to a positive non-zero integer value. This command simulates ro
 .. code-block:: python
 
   text = 'Roll: ' + str(action.data.get('roll_unmodified')) + " , Result: " + str(action.data.get('roll_modified'))
-  action.community.notify_action(action, policy, users, template=text, channel = "733209360549019688")
+  action.community.post_message(text=text, channel = "733209360549019688")
 
 **Fail:**
 
 .. code-block:: python
 
   text = 'Error: Make sure you format your dice roll command correctly!'
-  action.community.notify_action(action, policy, users, template=text, channel = "733209360549019688")
+  action.community.post_message(text=text, channel = "733209360549019688")
 
 Lottery / Raffle
 ------------------------
@@ -237,7 +221,7 @@ Allow users to vote on a "lottery" message, pick a random user as the lottery wi
   if tokens[0] != "!lottery":
     return False
   if len(tokens) != 2:
-    action.community.notify_action(action, policy, users, template='need a lottery message', channel = "733209360549019688")
+    action.community.post_message(text='need a lottery message', channel = "733209360549019688")
     return False
   action.data.set('message', tokens[1])
   return True
@@ -249,7 +233,7 @@ Allow users to vote on a "lottery" message, pick a random user as the lottery wi
 .. code-block:: python
 
   message = action.data.get('message')
-  action.community.notify_action(action, policy, users, template=message, channel = "733209360549019688")
+  action.community.initiate_vote(action, policy, template=message, channel = "733209360549019688")
 
 **Check:**
 
@@ -271,7 +255,7 @@ Allow users to vote on a "lottery" message, pick a random user as the lottery wi
   winner = random.randint(0, num_votes)
   winner_name = all_votes[winner].user.readable_name
   message = "Congratulations! " + winner_name + " has won the lottery!"
-  action.community.notify_action(action, policy, users, template=message, channel = "733209360549019688")
+  action.community.post_message(text=message, channel = "733209360549019688")
 
 **Fail:** ``pass``
 

--- a/policykit/integrations/discord/models.py
+++ b/policykit/integrations/discord/models.py
@@ -51,9 +51,12 @@ class DiscordCommunity(CommunityPlatform):
 
     team_id = models.CharField('team_id', max_length=150, unique=True)
 
-    def notify_action(self, action, policy, users=None, template=None, channel=None):
-        from integrations.discord.views import post_policy
-        post_policy(policy, action, users, template, channel)
+    def initiate_vote(self, action, policy, users=None, template=None, channel=None):
+        from integrations.discord.views import initiate_action_vote
+        initiate_action_vote(policy, action, users, template, channel)
+
+    def post_message(self, text, channel):
+        return self.make_call(f'channels/{channel}/messages', values={'content': text}, method="POST")
 
     def save(self, *args, **kwargs):
         super(DiscordCommunity, self).save(*args, **kwargs)
@@ -107,7 +110,7 @@ class DiscordPostMessage(PlatformAction):
     def execute(self):
         # Execute action if it didn't originate in the community OR it was previously reverted
         if not self.community_origin or (self.community_origin and self.community_revert):
-            message = self.community.make_call(f"channels/{self.channel_id}/messages", {'content': self.text})
+            message = self.community.post_message(text=self.text, channel=self.channel_id)
 
             self.message_id = message['id']
             self.community_post = self.message_id

--- a/policykit/integrations/discord/models.py
+++ b/policykit/integrations/discord/models.py
@@ -51,6 +51,9 @@ class DiscordCommunity(CommunityPlatform):
 
     team_id = models.CharField('team_id', max_length=150, unique=True)
 
+    def notify_action(self, *args, **kwargs):
+        self.initiate_vote(*args, **kwargs)
+
     def initiate_vote(self, action, policy, users=None, template=None, channel=None):
         from integrations.discord.views import initiate_action_vote
         initiate_action_vote(policy, action, users, template, channel)

--- a/policykit/integrations/discord/views.py
+++ b/policykit/integrations/discord/views.py
@@ -461,7 +461,7 @@ def auth(request, guild_id=None, access_token=None):
     else:
         return redirect('/login?error=invalid_login')
 
-def post_policy(policy, action, users=None, template=None, channel=None):
+def initiate_action_vote(policy, action, users=None, template=None, channel=None):
     message = "This action is governed by the following policy: " + policy.name
     if template:
         message = template
@@ -480,7 +480,7 @@ def post_policy(policy, action, users=None, template=None, channel=None):
     if channel_id == None:
         return
 
-    res = policy.community.make_call(f'channels/{channel_id}/messages', values={'content': message})
+    res = policy.community.post_message(text=message, channel=channel_id)
 
     if action.action_type == "ConstitutionAction" or action.action_type == "PlatformAction":
         action.community_post = res['id']

--- a/policykit/integrations/discourse/models.py
+++ b/policykit/integrations/discourse/models.py
@@ -27,9 +27,15 @@ class DiscourseCommunity(CommunityPlatform):
     team_id = models.CharField('team_id', max_length=150, unique=True)
     api_key = models.CharField('api_key', max_length=100, unique=True)
 
-    def notify_action(self, action, policy, users=None, template=None, topic_id=None):
-        from integrations.discourse.views import post_policy
-        post_policy(policy, action, users, template, topic_id)
+    def initiate_vote(self, action, policy, users=None, template=None, topic_id=None):
+        from integrations.discourse.views import initiate_action_vote
+        initiate_action_vote(policy, action, users, template, topic_id)
+
+    def post_message(self, text, topic_id):
+        # TODO: update this method to support commenting on an existing topic,
+        # sending DM, sending multi-person message, etc. Metagov Discourse supports this.
+        data = {'raw': text, 'topic_id': topic_id}
+        return self.make_call('/posts.json', values=data)
 
     def save(self, *args, **kwargs):
         super(DiscourseCommunity, self).save(*args, **kwargs)

--- a/policykit/integrations/discourse/views.py
+++ b/policykit/integrations/discourse/views.py
@@ -143,7 +143,7 @@ def action(request):
     logger.info('RECEIVED ACTION')
     logger.info(json_data)
 
-def post_policy(policy, action, users=None, template=None, topic_id=None):
+def initiate_action_vote(policy, action, users=None, template=None, topic_id=None):
     from policyengine.models import LogAPICall
 
     policy_message = "This action is governed by the following policy: " + policy.name

--- a/policykit/integrations/reddit/models.py
+++ b/policykit/integrations/reddit/models.py
@@ -111,10 +111,9 @@ class RedditCommunity(CommunityPlatform):
         self.access_token = res['access_token']
         self.save()
 
-    def notify_action(self, action, policy, users=None):
-        from redditintegration.views import post_policy
-        post_policy(policy, action, users)
-
+    def initiate_vote(self, action, policy, users=None):
+        from redditintegration.views import initiate_action_vote
+        initiate_action_vote(policy, action, users)
 
     def execute_platform_action(self, action, delete_policykit_post=True):
         from policyengine.models import LogAPICall, CommunityUser

--- a/policykit/integrations/reddit/views.py
+++ b/policykit/integrations/reddit/views.py
@@ -133,7 +133,7 @@ def action(request):
     logger.info('RECEIVED ACTION')
     logger.info(json_data)
 
-def post_policy(policy, action, users, template=None):
+def initiate_action_vote(policy, action, users, template=None):
     from policyengine.models import LogAPICall
 
     policy_message_default = "This action is governed by the following policy: " + policy.description + '. Vote by replying +1 or -1 to this post.'

--- a/policykit/integrations/slack/models.py
+++ b/policykit/integrations/slack/models.py
@@ -72,6 +72,10 @@ NUMBERS_TEXT = {
     "nine": 9,
 }
 
+# Name of generic Slack action in Metagov
+# See: https://metagov.policykit.org/redoc/#operation/slack.method
+SLACK_METHOD_ACTION = "slack.method"
+
 
 class SlackUser(CommunityUser):
     pass
@@ -82,7 +86,7 @@ class SlackCommunity(CommunityPlatform):
 
     team_id = models.CharField("team_id", max_length=150, unique=True)
 
-    def notify_action(self, action, policy, users=[], post_type="channel", template=None, channel=None):
+    def initiate_vote(self, action, policy, users=None, post_type="channel", template=None, channel=None):
         SlackUtils.start_emoji_vote(policy, action, users, post_type, template, channel)
 
     def make_call(self, method_name, values={}, action=None, method=None):
@@ -221,7 +225,7 @@ class SlackCommunity(CommunityPlatform):
                         existing_vote.number_value = num
                         existing_vote.save()
 
-    def post_message(self, text, users=[], post_type="channel", channel=None):
+    def post_message(self, text, users=[], post_type="channel", channel=None, thread_ts=None, reply_broadcast=False):
         """
         POST TYPES:
         mpim = multi person message
@@ -232,11 +236,13 @@ class SlackCommunity(CommunityPlatform):
         usernames = [user.username for user in users or []]
         if len(usernames) == 0 and post_type in ["mpim", "im", "ephemeral"]:
             raise Exception(f"user(s) required for post type '{post_type}'")
+        if channel is None and post_type in ["channel", "ephemeral"]:
+            raise Exception(f"channel required for post type '{post_type}'")
+
         values = {"text": text}
 
         if post_type == "mpim":
             # post to group message
-            values["channel"] = channel
             values["users"] = usernames
             response = LogAPICall.make_api_call(self, values, "slack.post-message")
             return [response["ts"]]
@@ -245,7 +251,6 @@ class SlackCommunity(CommunityPlatform):
             # message each user individually
             posts = []
             for username in usernames:
-                values["channel"] = channel
                 values["users"] = [username]
                 response = LogAPICall.make_api_call(self, values, "slack.post-message")
                 posts.append(response["ts"])
@@ -262,6 +267,11 @@ class SlackCommunity(CommunityPlatform):
 
         if post_type == "channel":
             values["channel"] = channel
+            if thread_ts:
+                # post message in response as a threaded message reply
+                values["thread_ts"] = thread_ts
+                values["reply_broadcast"] = reply_broadcast
+
             response = LogAPICall.make_api_call(self, values, "slack.post-message")
             return [response["ts"]]
 
@@ -270,7 +280,7 @@ class SlackCommunity(CommunityPlatform):
     def __make_generic_api_call(self, method: str, values):
         """Make any Slack method request using Metagov action 'slack.method' """
         cleaned = {k: v for k, v in values.items() if v is not None} if values else {}
-        return LogAPICall.make_api_call(self, {"method_name": method, **cleaned}, "slack.method")
+        return LogAPICall.make_api_call(self, {"method_name": method, **cleaned}, SLACK_METHOD_ACTION)
 
 
 class SlackPostMessage(PlatformAction):
@@ -296,7 +306,7 @@ class SlackPostMessage(PlatformAction):
             "ts": self.timestamp,
             "channel": self.channel,
         }
-        super().revert(values, "slack.method")
+        super().revert(values, SLACK_METHOD_ACTION)
 
 
 class SlackRenameConversation(PlatformAction):
@@ -317,15 +327,13 @@ class SlackRenameConversation(PlatformAction):
     def revert(self):
         # Slack docs: "only the user that originally created a channel or an admin may rename it"
         values = {
+            "method_name": SlackRenameConversation.ACTION,
             "name": self.previous_name,
             "channel": self.channel,
             # Use the initiators access token if we have it (since they already successfully renamed)
-            "token": self.initiator.access_token,
+            "token": self.initiator.access_token or self.community.__get_admin_user_token(),
         }
-        if not values["token"]:
-            # Use any admin user token that we have
-            values["token"] = self.community.__get_admin_user_token()
-        super().revert(values, "conversations.rename")
+        super().revert(values, SLACK_METHOD_ACTION)
 
 
 class SlackJoinConversation(PlatformAction):
@@ -343,17 +351,16 @@ class SlackJoinConversation(PlatformAction):
         permissions = (("can_execute_slackjoinconversation", "Can execute slack join conversation"),)
 
     def revert(self):
-        values = {"user": self.users, "channel": self.channel}
-        method = "conversations.kick"
+        values = {"method_name": "conversations.kick", "user": self.users, "channel": self.channel}
         try:
-            super().revert(values, method)
+            super().revert(values, SLACK_METHOD_ACTION)
         except Exception:
             # Whether or not bot can kick is based on workspace settings
-            logger.error(f"{method} with bot token failed, attempting with admin token")
+            logger.error(f"kick with bot token failed, attempting with admin token")
             values["token"] = self.community.__get_admin_user_token()
             # This will fail with `cant_kick_self` if a user is trying to kick itself.
             # TODO: handle that by using a different token or `conversations.leave` if we have the user's token
-            super().revert(values, method)
+            super().revert(values, SLACK_METHOD_ACTION)
 
 
 class SlackPinMessage(PlatformAction):
@@ -370,8 +377,8 @@ class SlackPinMessage(PlatformAction):
         permissions = (("can_execute_slackpinmessage", "Can execute slack pin message"),)
 
     def revert(self):
-        values = {"channel": self.channel, "timestamp": self.timestamp}
-        super().revert(values, "pins.remove")
+        values = {"method_name": "pins.remove", "channel": self.channel, "timestamp": self.timestamp}
+        super().revert(values, SLACK_METHOD_ACTION)
 
 
 class SlackScheduleMessage(PlatformAction):

--- a/policykit/integrations/slack/models.py
+++ b/policykit/integrations/slack/models.py
@@ -86,6 +86,9 @@ class SlackCommunity(CommunityPlatform):
 
     team_id = models.CharField("team_id", max_length=150, unique=True)
 
+    def notify_action(self, *args, **kwargs):
+        self.initiate_vote(*args, **kwargs)
+
     def initiate_vote(self, action, policy, users=None, post_type="channel", template=None, channel=None):
         SlackUtils.start_emoji_vote(policy, action, users, post_type, template, channel)
 

--- a/policykit/policyengine/filter.py
+++ b/policykit/policyengine/filter.py
@@ -320,7 +320,7 @@ policyengine_functions = [
     'get_all_boolean_votes',
     'get_all_number_votes',
     'get_one_number_votes',
-    'notify_action',
+    'initiate_vote',
     'get_time_elapsed',
     'get_users',
     'genericrole_set.all',

--- a/policykit/policyengine/models.py
+++ b/policykit/policyengine/models.py
@@ -86,7 +86,7 @@ class CommunityPlatform(PolymorphicModel):
     def metagov_slug(self):
         return self.community.metagov_slug
 
-    def notify_action(self, action, policy, users):
+    def initiate_vote(self, action, policy, users):
         """
         Sends a notification to users of a pending action.
 

--- a/policykit/scripts/starterkits.py
+++ b/policykit/scripts/starterkits.py
@@ -513,7 +513,7 @@ elif action.proposal.get_time_elapsed() > datetime.timedelta(days=1):
                                            """,
     notify="""
 voter_users = users.filter(groups__name__in=['Democracy: Voter'])
-action.community.notify_action(action, policy, users=voter_users, template='Please vote')
+action.community.initiate_vote(action, policy, users=voter_users, template='Please vote')
                                            """,
     success="action.execute()",
     fail="pass",
@@ -553,7 +553,7 @@ elif action.proposal.get_time_elapsed() > datetime.timedelta(days=1):
                                                            """,
     notify="""
 voter_users = users.filter(groups__name__in=['Democracy: Voter'])
-action.community.notify_action(action, policy, users=voter_users, template='Please vote')
+action.community.initiate_vote(action, policy, users=voter_users, template='Please vote')
                                                            """,
     success="action.execute()",
     fail="pass",
@@ -595,7 +595,7 @@ elif action.proposal.get_time_elapsed() > datetime.timedelta(days=1):
     return FAILED
                                                            """,
     notify="""
-action.community.notify_action(action, policy, users, template='Please vote on proposal')
+action.community.initiate_vote(action, policy, users, template='Please vote on proposal')
                                                            """,
     success="action.execute()",
     fail="pass",
@@ -635,7 +635,7 @@ elif action.proposal.get_time_elapsed() > datetime.timedelta(days=1):
                                                            """,
     notify="""
 voter_users = users.filter(groups__name__in=['Democracy: Voter'])
-action.community.notify_action(action, policy, users=voter_users, template='Please vote')
+action.community.initiate_vote(action, policy, users=voter_users, template='Please vote')
                                                            """,
     success="action.execute()",
     fail="pass",
@@ -1127,7 +1127,7 @@ elif action.proposal.get_time_elapsed() > datetime.timedelta(days=2):
     notify="""
 jury = action.data.get('jury')
 jury_users = users.filter(username__in=jury)
-action.community.notify_action(action, policy, users=jury_users, template='Please deliberate amongst yourselves before voting')
+action.community.initiate_vote(action, policy, users=jury_users, template='Please deliberate amongst yourselves before voting')
                                            """,
     success="action.execute()",
     fail="pass",
@@ -1166,7 +1166,7 @@ elif action.proposal.get_time_elapsed() > datetime.timedelta(days=2):
     notify="""
 jury = action.data.get('jury')
 jury_users = users.filter(username__in=jury)
-action.community.notify_action(action, policy, users=jury_users, template='Please deliberate amongst yourselves before voting')
+action.community.initiate_vote(action, policy, users=jury_users, template='Please deliberate amongst yourselves before voting')
                                            """,
     success="action.execute()",
     fail="pass",
@@ -1205,7 +1205,7 @@ elif action.proposal.get_time_elapsed() > datetime.timedelta(days=2):
     notify="""
 jury = action.data.get('jury')
 jury_users = users.filter(username__in=jury)
-action.community.notify_action(action, policy, users=jury_users, template='Please deliberate amongst yourselves before voting')
+action.community.initiate_vote(action, policy, users=jury_users, template='Please deliberate amongst yourselves before voting')
                                            """,
     success="action.execute()",
     fail="pass",
@@ -1244,7 +1244,7 @@ elif action.proposal.get_time_elapsed() > datetime.timedelta(days=2):
     notify="""
 jury = action.data.get('jury')
 jury_users = users.filter(username__in=jury)
-action.community.notify_action(action, policy, users=jury_users, template='Please deliberate amongst yourselves before voting')
+action.community.initiate_vote(action, policy, users=jury_users, template='Please deliberate amongst yourselves before voting')
                                            """,
     success="action.execute()",
     fail="pass",


### PR DESCRIPTION
Closes https://github.com/amyxzhang/policykit/issues/413

1. Rename `notify_action` to `initiate_vote`. The function signatures are unchanged.
2. Add method `post_message` to all communities. The common-ish API is `post_message(text, users, channel)` and each platform can have additional optional params on top of that.
3. Update all the sample policies.
4. Fix a few bugs in the Slack integrator that I found while doing this. The bug fixes are totally unrelated to the above items 🙈.  all bugs that I had introduced with https://github.com/amyxzhang/policykit/pull/408 .