### PR TITLE
Fix issue where celery runs old version of code

### DIFF
--- a/policykit/policyengine/tasks.py
+++ b/policykit/policyengine/tasks.py
@@ -4,18 +4,19 @@ import logging
 
 from celery import shared_task
 from django.utils import timezone
-from django_db_logger.models import EvaluationLog
-from policykit.settings import DB_LOG_EXPIRATION_HOURS
 
-from policyengine.models import ConstitutionAction, PlatformAction, Proposal
-from policyengine.views import govern_action
 
 logger = logging.getLogger(__name__)
 
+
 @shared_task
 def consider_proposed_actions():
+    # import PK modules inside the task so we get code updates.
+    from policyengine.views import govern_action
+    from policyengine.models import ConstitutionAction, PlatformAction, Proposal
+
     platform_actions = PlatformAction.objects.filter(proposal__status=Proposal.PROPOSED, is_bundled=False)
-    logger.info(f"{platform_actions.count()} proposed PlatformActions")
+    logger.debug(f"{platform_actions.count()} proposed PlatformActions")
     for action in platform_actions:
         govern_action(action, is_first_evaluation=False)
 
@@ -24,16 +25,19 @@ def consider_proposed_actions():
         govern_action(action, is_first_evaluation=False)"""
 
     constitution_actions = ConstitutionAction.objects.filter(proposal__status=Proposal.PROPOSED, is_bundled=False)
-    logger.info(f"{constitution_actions.count()} proposed ConstitutionActions")
+    logger.debug(f"{constitution_actions.count()} proposed ConstitutionActions")
     for action in constitution_actions:
         govern_action(action, is_first_evaluation=False)
 
     clean_up_logs()
-    logger.info('finished task')
+    logger.debug("finished task")
 
 
 def clean_up_logs():
-    hours_ago = timezone.now()-timezone.timedelta(hours=DB_LOG_EXPIRATION_HOURS)
-    count,_ = EvaluationLog.objects.filter(create_datetime__lt=hours_ago).delete()
+    from policykit.settings import DB_LOG_EXPIRATION_HOURS
+    from django_db_logger.models import EvaluationLog
+
+    hours_ago = timezone.now() - timezone.timedelta(hours=DB_LOG_EXPIRATION_HOURS)
+    count, _ = EvaluationLog.objects.filter(create_datetime__lt=hours_ago).delete()
     if count:
-        logger.info(f"Deleted {count} EvaluationLogs")
+        logger.debug(f"Deleted {count} EvaluationLogs")


### PR DESCRIPTION
I was running into an issue where celery was running pending tasks with an old version of the polciyengine code. Typically `systempctl restart celery` is required to get the updates, but for some reason that wasn't working. Even stopping and starting celery didn't work. This is the change that ultimately fixed it. I'm not sure why I'm only hitting this now. left a comment in there for future reference 