### PR TITLE
Show pending actions on dashboard, add more events to action log

### DIFF
--- a/policykit/integrations/slack/models.py
+++ b/policykit/integrations/slack/models.py
@@ -296,6 +296,7 @@ class SlackPostMessage(PlatformAction):
     timestamp = models.CharField(max_length=32, blank=True)
 
     action_codename = "slackpostmessage"
+    readable_name = "post message"
     app_name = "slackintegration"
 
     class Meta:
@@ -322,6 +323,7 @@ class SlackRenameConversation(PlatformAction):
     previous_name = models.CharField(max_length=80)
 
     action_codename = "slackrenameconversation"
+    readable_name = "rename conversation"
     app_name = "slackintegration"
 
     class Meta:
@@ -348,6 +350,7 @@ class SlackJoinConversation(PlatformAction):
     users = models.CharField("users", max_length=15)
 
     action_codename = "slackjoinconversation"
+    readable_name = "join conversation"
     app_name = "slackintegration"
 
     class Meta:
@@ -374,6 +377,7 @@ class SlackPinMessage(PlatformAction):
     timestamp = models.CharField(max_length=32)
 
     action_codename = "slackpinmessage"
+    readable_name = "pin message"
     app_name = "slackintegration"
 
     class Meta:
@@ -393,6 +397,7 @@ class SlackScheduleMessage(PlatformAction):
     post_at = models.IntegerField("post at")
 
     action_codename = "slackschedulemessage"
+    readable_name = "schedule message"
     app_name = "slackintegration"
 
     class Meta:
@@ -408,6 +413,7 @@ class SlackKickConversation(PlatformAction):
     channel = models.CharField("channel", max_length=150)
 
     action_codename = "slackkickconversation"
+    readable_name = "remove user from conversation"
     app_name = "slackintegration"
 
     class Meta:

--- a/policykit/policyengine/utils.py
+++ b/policykit/policyengine/utils.py
@@ -17,17 +17,16 @@ def find_action_cls(app_name: str, action_codename: str):
                 return cls
     return None
 
-def get_action_codenames(app_name: str):
+def get_action_classes(app_name: str):
     """
-    Get a list of action_codenames for PlatformAction models defined in the given app
+    Get a list of PlatformAction subclasses defined in the given app
     """
     from policyengine.models import PlatformAction
-    action_list = []
+    actions = []
     for cls in apps.get_app_config(app_name).get_models():
-            if issubclass(cls, PlatformAction) and hasattr(cls, "action_codename"):
-                codename = getattr(cls, "action_codename")
-                action_list.append(codename)
-    return action_list
+        if issubclass(cls, PlatformAction) and hasattr(cls, "action_codename"):
+            actions.append(cls)
+    return actions
 
 def construct_authorize_install_url(request, integration, community):
     logger.debug(f"Constructing URL to install '{integration}' to community '{community}'.")

--- a/policykit/templates/policyadmin/dashboard/actions.html
+++ b/policykit/templates/policyadmin/dashboard/actions.html
@@ -122,9 +122,9 @@
         <div class="actionPanelContent">
           <table class="table table-hover">
             <tbody>
-              {% for codename in action_list %}
-                <tr class="actionItem" onclick="proposePlatformActionLink('{{ app_name }}', '{{ codename }}')">
-                  <td>Propose {{codename}}</td>
+              {% for action in action_list %}
+                <tr class="actionItem" onclick="proposePlatformActionLink('{{ app_name }}', '{{ action.action_codename }}')">
+                  <td>Propose {{action.readable_name|default:action.action_codename}}</td>
                 </tr>
               {% endfor %}
             </tbody>

--- a/policykit/templates/policyadmin/dashboard/index.html
+++ b/policykit/templates/policyadmin/dashboard/index.html
@@ -94,10 +94,11 @@
   .actionPanel {
     width: 90%;
     margin-right: auto;
-    min-height: 40em;
+    max-height: 40em;
     margin-top: 0.5em;
     background-color: #ffffff;
     border-radius: 20px;
+    margin-bottom: 2em;
   }
 
   .actionPanelTitle {
@@ -109,7 +110,7 @@
   .actionPanelContent {
     width: 92%;
     margin-left: 4%;
-    height: 33.5em;
+    max-height: 33.5em;
     overflow: auto;
   }
 
@@ -213,10 +214,26 @@
 <div class="body">
   <div class="leftCol">
     <!--<input type="text" class="searchBar" placeholder="Search">-->
-
-    <!--<div class="actionPanel">
+    <div class="actionPanel">
       <h3 class="actionPanelTitle">Pending actions</h3>
-    </div>-->
+      <div class="actionPanelContent">
+        <table class="table table-hover">
+          <tbody>
+              {% for action in pending_actions %}
+                <tr class="sidebarItem">
+                  <td>{{action}} by {{action.initiator}}</td>
+                  <td>{{action.proposal.proposal_time|timesince}} ago</td>
+                </tr>
+              {% empty %}
+                <tr class="sidebarItem">
+                  <td>No pending actions.</td>
+                </tr>
+              {% endfor %}
+          </tbody>
+        </table>
+      </div>
+    </div>
+
     <div class="actionPanel">
       <h3 class="actionPanelTitle">Recent actions</h3>
       <div class="actionPanelContent">
@@ -224,8 +241,12 @@
           <tbody>
             {% for action in action_log %}
               <tr class="sidebarItem">
-                <td>{{action.actor}}</td>
-                <td>{{action.time_elapsed}} ago</td>
+                <td>{{action.actor|capfirst}} {{action.verb|default_if_none:""}}</td>
+                <td>{{action.timesince}} ago</td>
+              </tr>
+            {% empty %}
+              <tr class="sidebarItem">
+                <td>No recent actions.</td>
               </tr>
             {% endfor %}
           </tbody>
@@ -300,6 +321,10 @@
               {% for key, value in docs.items %}
                 <tr id="document_{{key}}" class="sidebarItem">
                   <td>{{value.name}}</td>
+                </tr>
+              {% empty %}
+                <tr class="sidebarItem">
+                  <td>No documents.</td>
                 </tr>
               {% endfor %}
             </tbody>

--- a/policykit/templates/policyadmin/dashboard/index.html
+++ b/policykit/templates/policyadmin/dashboard/index.html
@@ -221,7 +221,7 @@
           <tbody>
               {% for action in pending_actions %}
                 <tr class="sidebarItem">
-                  <td>{{action}} by {{action.initiator}}</td>
+                  <td>{{action|capfirst}} by {{action.initiator}}</td>
                   <td>{{action.proposal.proposal_time|timesince}} ago</td>
                 </tr>
               {% empty %}


### PR DESCRIPTION
### In this PR
* Show pending actions on homepage
* Add actstream verbs for "was failed" and "was proposed" to the action log (in addition to "was passed" which was already present).
* Add optional `readable_name` static attribute to PlatformAction, to display in the UI (and use it on the "Propose Action" page as well)

### Ideas for improvement
* The action log / pending actions are still not super useful because they don't show any information about the action, since it could potentially be sensitive ie if the bot is added to a private chat or channel. To make this nicer, we may want to introduce a per-action attribute for readable description– for example "rename channel from X to Y" for SlackRenameChannel.
* Click on any action to see details about its evaluation & which policy applied to it (re: recent slack convo)


--

<img width="1061" alt="Screen Shot 2021-07-21 at 11 48 35" src="https://user-images.githubusercontent.com/5333982/126519217-35548a2b-9443-42a6-a5cf-b0c1992e5340.png">
