### PR TITLE
Multi-platform communities, part 1

### DIFF
--- a/policykit/integrations/slack/views.py
+++ b/policykit/integrations/slack/views.py
@@ -116,6 +116,8 @@ def slack_install(request):
             "community_name": slack_community.community_name,
             "creator_token": user_token,
             "platform": "slack",
+            # redirect to settings page or login page depending on whether it's a new community
+            "redirect": redirect_route
         }
         return render(request, "policyadmin/init_starterkit.html", context)
 

--- a/policykit/integrations/slack/views.py
+++ b/policykit/integrations/slack/views.py
@@ -3,12 +3,7 @@ import requests
 from django.conf import settings
 from django.contrib.auth import authenticate, login
 from django.shortcuts import redirect, render
-from integrations.slack.models import (
-    SlackCommunity,
-    SlackStarterKit,
-    SlackUser,
-    SLACK_METHOD_ACTION
-)
+from integrations.slack.models import SlackCommunity, SlackStarterKit, SlackUser, SLACK_METHOD_ACTION
 from integrations.slack.utils import get_slack_user_fields
 from policyengine.models import Community, CommunityRole
 
@@ -36,26 +31,31 @@ def slack_login(request):
 
 def slack_install(request):
     logger.debug(f"Slack installation completed: {request.GET}")
-    expected_state = request.session.get("community_install_state")
-    if expected_state is None or request.GET.get("state") is None or (not request.GET.get("state") == expected_state):
-        logger.error(f"expected {expected_state}")
-        return redirect("/login?error=bad_state")
-
-    if request.GET.get("error"):
-        return redirect(f"/login?error={request.GET.get('error')}")
 
     # metagov identifier for the "parent community" to install Slack to
     metagov_community_slug = request.GET.get("community")
-
-    # TODO(issue): stop passing user id and token
-    user_id = request.GET.get("user_id")
-    user_token = request.GET.get("user_token")
-
+    is_new_community = False
     try:
         community = Community.objects.get(metagov_slug=metagov_community_slug)
     except Community.DoesNotExist:
         logger.debug(f"Community not found: {metagov_community_slug}, creating it")
+        is_new_community = True
         community = Community.objects.create(metagov_slug=metagov_community_slug)
+
+    # if we're enabling an integration for an existing community, so redirect to the settings page
+    redirect_route = "/login" if is_new_community else "/main/settings"
+
+    expected_state = request.session.get("community_install_state")
+    if expected_state is None or request.GET.get("state") is None or (not request.GET.get("state") == expected_state):
+        logger.error(f"expected {expected_state}")
+        return redirect(f"{redirect_route}?error=bad_state")
+
+    if request.GET.get("error"):
+        return redirect(f"{redirect_route}?error={request.GET.get('error')}")
+
+    # TODO(issue): stop passing user id and token
+    user_id = request.GET.get("user_id")
+    user_token = request.GET.get("user_token")
 
     # Get team info from Slack
     response = requests.post(
@@ -64,7 +64,7 @@ def slack_install(request):
         headers={"X-Metagov-Community": metagov_community_slug},
     )
     if not response.ok:
-        return redirect("/login?error=server_error")
+        return redirect(f"{redirect_route}?error=server_error")
     data = response.json()
     team = data["team"]
     team_id = team["id"]
@@ -94,6 +94,7 @@ def slack_install(request):
         # get the list of users, create SlackUser object for each user
         logger.debug(f"Fetching user list for {slack_community}...")
         from policyengine.models import LogAPICall
+
         response = LogAPICall.make_api_call(slack_community, {"method_name": "users.list"}, SLACK_METHOD_ACTION)
         for new_user in response["members"]:
             if (not new_user["deleted"]) and (not new_user["is_bot"]) and (new_user["id"] != "USLACKBOT"):
@@ -147,6 +148,4 @@ def slack_install(request):
                     defaults=user_fields,
                 )
 
-        return redirect("/login?success=true")
-
-
+        return redirect(f"{redirect_route}?success=true")

--- a/policykit/integrations/slack/views.py
+++ b/policykit/integrations/slack/views.py
@@ -54,8 +54,8 @@ def slack_install(request):
     try:
         community = Community.objects.get(metagov_slug=metagov_community_slug)
     except Community.DoesNotExist:
-        logger.error(f"Community not found: {metagov_community_slug}")
-        return redirect("/login?error=community_not_found")
+        logger.debug(f"Community not found: {metagov_community_slug}, creating it")
+        community = Community.objects.create(metagov_slug=metagov_community_slug)
 
     # Get team info from Slack
     response = requests.post(

--- a/policykit/policyengine/utils.py
+++ b/policykit/policyengine/utils.py
@@ -34,8 +34,13 @@ def construct_authorize_install_url(request, integration, community=None):
     # Initiate authorization flow to install Metagov to platform.
     # On successful completion, the Metagov Slack plugin will be enabled for the community.
 
-    # redirect_uri is the endpoint that will create the SlackCommunity after the authorization succeeds
-    redirect_uri = f"{settings.SERVER_URL}/{integration}/install"
+    if community is None:
+        # we're creating a new community, so redirect to the install endpoint which will complete
+        # the setup process (ie create the SlackCommunity) and redirect to /login when complete.
+        redirect_uri = f"{settings.SERVER_URL}/{integration}/install"
+    else:
+        # we're enabling an integration for an existing community, so redirect to the settings page
+        redirect_uri = f"{settings.SERVER_URL}/main/settings"
     encoded_redirect_uri = quote(redirect_uri, safe='')
 
     # store state in user's session so we can validate it later

--- a/policykit/policyengine/utils.py
+++ b/policykit/policyengine/utils.py
@@ -34,13 +34,8 @@ def construct_authorize_install_url(request, integration, community=None):
     # Initiate authorization flow to install Metagov to platform.
     # On successful completion, the Metagov Slack plugin will be enabled for the community.
 
-    if community is None:
-        # we're creating a new community, so redirect to the install endpoint which will complete
-        # the setup process (ie create the SlackCommunity) and redirect to /login when complete.
-        redirect_uri = f"{settings.SERVER_URL}/{integration}/install"
-    else:
-        # we're enabling an integration for an existing community, so redirect to the settings page
-        redirect_uri = f"{settings.SERVER_URL}/main/settings"
+    # Redirect to the plugin-specific install endpoint, which will complete the setup process (ie create the SlackCommunity)
+    redirect_uri = f"{settings.SERVER_URL}/{integration}/install"
     encoded_redirect_uri = quote(redirect_uri, safe='')
 
     # store state in user's session so we can validate it later

--- a/policykit/policyengine/utils.py
+++ b/policykit/policyengine/utils.py
@@ -28,7 +28,7 @@ def get_action_classes(app_name: str):
             actions.append(cls)
     return actions
 
-def construct_authorize_install_url(request, integration, community):
+def construct_authorize_install_url(request, integration, community=None):
     logger.debug(f"Constructing URL to install '{integration}' to community '{community}'.")
 
     # Initiate authorization flow to install Metagov to platform.
@@ -42,6 +42,8 @@ def construct_authorize_install_url(request, integration, community):
     state = "".join([str(random.randint(0, 9)) for i in range(8)])
     request.session['community_install_state'] = state
 
-    url = f"{settings.METAGOV_URL}/auth/{integration}/authorize?type=app&community={community.metagov_slug}&redirect_uri={encoded_redirect_uri}&state={state}"
+    # if not specified, metagov will create a new community and pass back the slug
+    community_slug = community.metagov_slug if community else ''
+    url = f"{settings.METAGOV_URL}/auth/{integration}/authorize?type=app&community={community_slug}&redirect_uri={encoded_redirect_uri}&state={state}"
     logger.debug(url)
     return url

--- a/policykit/policyengine/views.py
+++ b/policykit/policyengine/views.py
@@ -30,9 +30,7 @@ def authorize_platform(request):
     platform = request.GET.get('platform')
     if not platform or platform != "slack":
         return HttpResponseBadRequest()
-    from policyengine.models import Community
-    new_community = Community.objects.create()
-    url = construct_authorize_install_url(request, integration=platform, community=new_community)
+    url = construct_authorize_install_url(request, integration=platform)
     return HttpResponseRedirect(url)
 
 @login_required(login_url='/login')
@@ -168,10 +166,10 @@ def settings_page(request):
 
         # FIXME(#384) support multi-platform communities. Here we're hiding slack from the "Add Integrations" dropdown,
         # because we don't have support for multiple CommunityPlatforms connected to one Community.
-        disabled_integrations_mod = [(k, v) for (k,v) in disabled_integrations if k not in ["slack"]]
+        # disabled_integrations_mod = [(k, v) for (k,v) in disabled_integrations if k not in ["slack"]]
 
         context["enabled_integrations"] = enabled_integrations.items()
-        context["disabled_integrations"] = disabled_integrations_mod
+        context["disabled_integrations"] = disabled_integrations
 
     return render(request, 'policyadmin/dashboard/settings.html', context)
 

--- a/policykit/policyengine/views.py
+++ b/policykit/policyengine/views.py
@@ -613,8 +613,7 @@ def clean_up_proposals(action, executed):
 
 @csrf_exempt
 def initialize_starterkit(request):
-    from policyengine.models import StarterKit, PlatformPolicy, ConstitutionPolicy, CommunityRole, CommunityUser, Proposal, CommunityPlatform
-    from django.contrib.auth.models import Permission
+    from policyengine.models import StarterKit, CommunityPlatform
 
     starterkit_name = request.POST['starterkit']
     community_name = request.POST['community_name']
@@ -628,8 +627,11 @@ def initialize_starterkit(request):
 
     logger.info('starterkit initialized')
 
-    response = redirect('/login?success=true')
-    return response
+    redirect_route = request.GET.get("redirect")
+    if redirect_route:
+        return redirect(f"{redirect_route}?success=true")
+
+    return redirect('/login?success=true')
 
 @csrf_exempt
 def error_check(request):

--- a/policykit/policyengine/views.py
+++ b/policykit/policyengine/views.py
@@ -164,10 +164,6 @@ def settings_page(request):
 
         disabled_integrations = [(k, v) for (k,v) in integration_data.items() if k not in enabled_integrations.keys()]
 
-        # FIXME(#384) support multi-platform communities. Here we're hiding slack from the "Add Integrations" dropdown,
-        # because we don't have support for multiple CommunityPlatforms connected to one Community.
-        # disabled_integrations_mod = [(k, v) for (k,v) in disabled_integrations if k not in ["slack"]]
-
         context["enabled_integrations"] = enabled_integrations.items()
         context["disabled_integrations"] = disabled_integrations
 

--- a/policykit/policyengine/views.py
+++ b/policykit/policyengine/views.py
@@ -240,6 +240,11 @@ def disable_integration(request):
     if community.platform == name:
         return redirect("/main/settings?error=not_permitted")
 
+    # Temporary: disallow disabling the plugins that have a corresponding PlatformCommunity.
+    # We would need to delete the SlackCommunity as well, which we should show a warning for!
+    if community.platform == "slack":
+        return redirect("/main/settings?error=not_permitted")
+
     logger.debug(f"Deleting plugin {name} {id}")
     MetagovAPI.delete_plugin(name=name, id=id)
     return redirect("/main/settings")

--- a/policykit/templates/policyadmin/dashboard/settings.html
+++ b/policykit/templates/policyadmin/dashboard/settings.html
@@ -77,7 +77,7 @@
 {% if request.GET.error %}
   <div class="alert alert-danger" role="alert">
     {% if request.GET.error == 'slack_wrong_community' %}
-      Failed to add Slack integration. PolicyKit is already installed to the selected workspace, but for a different PolicyKit community. Uninstall the PolicyKit app from your Slack workspace and try again.
+      Failed to add Slack integration. PolicyKit is already installed to the selected workspace, but for a different PolicyKit community. Contact a PolicyKit administrator for support.
     {% elif request.GET.error == 'slack_installer_is_not_admin' %}
       Failed to add Slack integration. Only Slack workspace admins are permitted to install PolicyKit.
     {% else %}

--- a/policykit/templates/policyadmin/dashboard/settings.html
+++ b/policykit/templates/policyadmin/dashboard/settings.html
@@ -50,6 +50,18 @@
 {% endblock %}
 
 {% block content %}
+{% if request.GET.error %}
+  <div class="error">
+    {% if request.GET.error == 'slack_wrong_community' %}
+      Failed to add Slack integration. PolicyKit is already installed to the selected workspace. Uninstall PolicyKit from your Slack workspace and try again.
+    {% elif request.GET.error == 'slack_installer_is_not_admin' %}
+      Failed to add Slack integration. Only Slack workspace admins are permitted to install PolicyKit.
+    {% else %}
+      Error: {{ request.GET.error }}
+    {% endif %}
+  </div>
+{% endif %}
+
 <div class="form-row title-row">
   <div class="col-sm-8">
     <h2>Integrations</h2>

--- a/policykit/templates/policyadmin/dashboard/settings.html
+++ b/policykit/templates/policyadmin/dashboard/settings.html
@@ -86,6 +86,12 @@
   </div>
 {% endif %}
 
+{% if request.GET.success %}
+  <div class="alert alert-success" role="alert">
+    Integration added!
+  </div>
+{% endif %}
+
 {% if not metagov_enabled %}
   <div class="card">
     <div class="card-body">

--- a/policykit/templates/policyadmin/dashboard/settings.html
+++ b/policykit/templates/policyadmin/dashboard/settings.html
@@ -50,17 +50,6 @@
 {% endblock %}
 
 {% block content %}
-{% if request.GET.error %}
-  <div class="error">
-    {% if request.GET.error == 'slack_wrong_community' %}
-      Failed to add Slack integration. PolicyKit is already installed to the selected workspace. Uninstall PolicyKit from your Slack workspace and try again.
-    {% elif request.GET.error == 'slack_installer_is_not_admin' %}
-      Failed to add Slack integration. Only Slack workspace admins are permitted to install PolicyKit.
-    {% else %}
-      Error: {{ request.GET.error }}
-    {% endif %}
-  </div>
-{% endif %}
 
 <div class="form-row title-row">
   <div class="col-sm-8">
@@ -84,6 +73,18 @@
     {% endif %}
   </div>
 </div>
+
+{% if request.GET.error %}
+  <div class="alert alert-danger" role="alert">
+    {% if request.GET.error == 'slack_wrong_community' %}
+      Failed to add Slack integration. PolicyKit is already installed to the selected workspace, but for a different PolicyKit community. Uninstall the PolicyKit app from your Slack workspace and try again.
+    {% elif request.GET.error == 'slack_installer_is_not_admin' %}
+      Failed to add Slack integration. Only Slack workspace admins are permitted to install PolicyKit.
+    {% else %}
+      Error: {{ request.GET.error }}
+    {% endif %}
+  </div>
+{% endif %}
 
 {% if not metagov_enabled %}
   <div class="card">

--- a/policykit/templates/policyadmin/init_starterkit.html
+++ b/policykit/templates/policyadmin/init_starterkit.html
@@ -255,7 +255,7 @@
             </div>
         </div>
         
-        <form action="/main/policyengine/initialize_starterkit" method="post" name="form" id="form">
+        <form action="/main/policyengine/initialize_starterkit?redirect={{redirect|default_if_none:''}}" method="post" name="form" id="form">
             
             <label for="starterkit">Choose a System of Governance:</label>
             <div class="images">

--- a/policykit/templates/policyadmin/login.html
+++ b/policykit/templates/policyadmin/login.html
@@ -25,7 +25,15 @@
 {% block content %}
 
 {% if request.GET.error %}
-  Error: {{ request.GET.error }}
+  <div class="error">
+    {% if request.GET.error == 'slack_wrong_community' %}
+      PolicyKit is already installed to your Slack workspace! Sign in with Slack to continue.
+    {% elif request.GET.error == 'slack_installer_is_not_admin' %}
+      Installation failed! Only Slack workspace admins are permitted to install PolicyKit.
+    {% else %}
+      Error: {{ request.GET.error }}
+    {% endif %}
+  </div>
 {% endif %}
 
 {% if request.GET.success %}


### PR DESCRIPTION
Beginning support for multi-platform communities. I have this working for Discord + Slack. Because Discord isn't a Metagov plugin, yet, it has to be added in a specific order (Create PK Community using Discord, THEN add the Slack integration). After that, the user still has to log in and out to access the distinct DiscordCommunity and SlackCommunity, which still have separate policies and everything. The only thing they DO share is the integrations. So if I add an OpenCollective or Loomio integration in one community, it will also be present in the other one.

This also implements some better error handling logic, as specified in # 2 here https://github.com/amyxzhang/policykit/issues/384#issuecomment-882638075.

MUST be deployed with https://github.com/metagov/metagov-prototype/pull/101

## Walkthrough Discord+Slack example with screenshots
1. Install PolicyKit to Discord server "miri's server"
2. Sign in with Discord to "miri's server"
3. Go to the Settings page and enable SourceCred
4. Go to the Settings page and enable Slack
  <img width="500" alt="Screen Shot 2021-07-21 at 15 55 51" src="https://user-images.githubusercontent.com/5333982/126556064-2e5f92b7-abfc-45b7-b325-a945156b9e8d.png">
  ...give my consent to slack workspace "test workspace"...
  <img width="500" alt="Screen Shot 2021-07-21 at 16 12 29" src="https://user-images.githubusercontent.com/5333982/126556234-cdfa86b8-145e-43b3-95d5-8219692a645c.png">
  ...select a starterkit for my new SlackCommunity ...
   <img width="500" alt="Screen Shot 2021-07-21 at 16 12 40" src="https://user-images.githubusercontent.com/5333982/126556363-c4ad43e0-9a2e-40fc-bb67-79e23b1f772b.png">
  ...redirected back to settings page for "miri's server"...
    <img width="500" alt="Screen Shot 2021-07-21 at 16 23 24" src="https://user-images.githubusercontent.com/5333982/126556419-4f9210c1-dd26-41b6-bef9-c0c405589856.png">
5. Sign out

6. Sign in with Slack org "test workspace"

7. Go to Settings page. All the Plugins that are enabled for the DiscordCommunity are also enabled for this SlackCommunity!
   <img width="500" alt="Screen Shot 2021-07-21 at 16 31 12" src="https://user-images.githubusercontent.com/5333982/126556598-be66d4a7-f10a-46f1-b9bf-d2e70455a696.png">

8. In the database, the SlackCommunity and DiscordCommunity have the same parent Community.