### PR TITLE
Enable GitHub integration through Metagov

### DIFF
--- a/policykit/integrations/github/__init__.py
+++ b/policykit/integrations/github/__init__.py
@@ -1,0 +1,1 @@
+default_app_config = 'integrations.github.apps.GithubIntegrationConfig'

--- a/policykit/integrations/github/apps.py
+++ b/policykit/integrations/github/apps.py
@@ -1,0 +1,5 @@
+from django.apps import AppConfig
+
+
+class GithubIntegrationConfig(AppConfig):
+    name = 'integrations.github'

--- a/policykit/integrations/github/urls.py
+++ b/policykit/integrations/github/urls.py
@@ -1,0 +1,8 @@
+from django.urls import path
+
+from integrations.github import views
+
+
+urlpatterns = [
+    path('install', views.github_install)
+]

--- a/policykit/integrations/github/views.py
+++ b/policykit/integrations/github/views.py
@@ -1,0 +1,34 @@
+import logging
+import requests
+from django.conf import settings
+from django.shortcuts import redirect
+from policyengine.models import Community, CommunityRole
+
+logger = logging.getLogger(__name__)
+
+
+def github_install(request):
+    logger.debug(f"GitHub installation completed: {request.GET}")
+
+    # metagov identifier for the "parent community" to install GitHub to
+    metagov_community_slug = request.GET.get("community")
+    is_new_community = False
+    try:
+        community = Community.objects.get(metagov_slug=metagov_community_slug)
+    except Community.DoesNotExist:
+        logger.debug(f"Community not found: {metagov_community_slug}, creating it")
+        is_new_community = True
+        community = Community.objects.create(metagov_slug=metagov_community_slug)
+
+    # if we're enabling an integration for an existing community, so redirect to the settings page
+    redirect_route = "/login" if is_new_community else "/main/settings"
+
+    expected_state = request.session.get("community_install_state")
+    if expected_state is None or request.GET.get("state") is None or (not request.GET.get("state") == expected_state):
+        logger.error(f"expected {expected_state}")
+        return redirect(f"{redirect_route}?error=bad_state")
+
+    if request.GET.get("error"):
+        return redirect(f"{redirect_route}?error={request.GET.get('error')}")
+
+    return redirect(f"{redirect_route}?success=true")

--- a/policykit/integrations/github/views.py
+++ b/policykit/integrations/github/views.py
@@ -2,7 +2,7 @@ import logging
 import requests
 from django.conf import settings
 from django.shortcuts import redirect
-from policyengine.models import Community, CommunityRole
+from policyengine.models import Community
 
 logger = logging.getLogger(__name__)
 
@@ -12,17 +12,15 @@ def github_install(request):
 
     # metagov identifier for the "parent community" to install GitHub to
     metagov_community_slug = request.GET.get("community")
-    is_new_community = False
+    # we can only add GitHub to existing communities for now, so redirect to the settings page
+    redirect_route = "/main/settings"
+
     try:
-        community = Community.objects.get(metagov_slug=metagov_community_slug)
+        Community.objects.get(metagov_slug=metagov_community_slug)
     except Community.DoesNotExist:
-        logger.debug(f"Community not found: {metagov_community_slug}, creating it")
-        is_new_community = True
-        community = Community.objects.create(metagov_slug=metagov_community_slug)
+        return redirect(f"{redirect_route}?error=community_not_found")
 
-    # if we're enabling an integration for an existing community, so redirect to the settings page
-    redirect_route = "/login" if is_new_community else "/main/settings"
-
+    # validate state
     expected_state = request.session.get("community_install_state")
     if expected_state is None or request.GET.get("state") is None or (not request.GET.get("state") == expected_state):
         logger.error(f"expected {expected_state}")

--- a/policykit/policyengine/integration_data.py
+++ b/policykit/policyengine/integration_data.py
@@ -12,6 +12,7 @@ integration_data = {
         "webhook_instructions": "Log into Loomio as an administrator, and navigate to Settings > Integrations > Edit Integration > Webhook. Enter the Webhook URL. Select Markdown format and all event types.",
     },
     "slack": {"readable_name": "Slack", "hide_config": True},
+    "github": {"readable_name": "GitHub", "hide_config": True},
     "sourcecred": {
         "readable_name": "SourceCred",
         "description": "SourceCred is a tool for communities to measure and reward value creation. Connect to an existing SourceCred instance in order to use Cred and Grain values in PolicyKit policies.",

--- a/policykit/policyengine/integration_data.py
+++ b/policykit/policyengine/integration_data.py
@@ -12,7 +12,6 @@ integration_data = {
         "webhook_instructions": "Log into Loomio as an administrator, and navigate to Settings > Integrations > Edit Integration > Webhook. Enter the Webhook URL. Select Markdown format and all event types.",
     },
     "slack": {"readable_name": "Slack", "hide_config": True},
-    "github": {"readable_name": "GitHub", "hide_config": True},
     "sourcecred": {
         "readable_name": "SourceCred",
         "description": "SourceCred is a tool for communities to measure and reward value creation. Connect to an existing SourceCred instance in order to use Cred and Grain values in PolicyKit policies.",
@@ -28,4 +27,5 @@ integration_data = {
         "description": "Use the MailGun APIs to send emails from PolicyKit policies.",
     },
     "near": {"readable_name": "NEAR", "description": "Make calls to a NEAR smart contracts from PolicyKit policies."},
+    "github": {"readable_name": "GitHub"},
 }

--- a/policykit/policyengine/models.py
+++ b/policykit/policyengine/models.py
@@ -756,8 +756,11 @@ class PolicykitAddUserRole(ConstitutionAction):
     ready = False
 
     def __str__(self):
-        if self.role:
-            return "Add User: " + str(self.users.all()[0]) + " to Role: " + self.role.role_name
+        first_user = self.users.first()
+        if self.role and first_user:
+            return "Add User: " + str(first_user) + " to Role: " + self.role.role_name
+        elif first_user is None:
+            return f"Add User: [ERROR: no users] to role {self.role.role_name}"
         else:
             return "Add User to Role: [ERROR: role not found]"
 

--- a/policykit/policyengine/views.py
+++ b/policykit/policyengine/views.py
@@ -230,16 +230,16 @@ def disable_integration(request):
 
     if not user.has_perm("metagov.can_edit_metagov_config"):
         logger.error(f"User {user} does not have permission to disable plugin.")
-        return redirect("/main/settings?error=not_permitted")
+        return redirect("/main/settings?error=insufficient_permissions")
 
     # hack: disallow disabling the plugin if the user is logged in with it
     if community.platform == name:
-        return redirect("/main/settings?error=not_permitted")
+        return redirect("/main/settings?error=cant_delete_current_platform")
 
     # Temporary: disallow disabling the plugins that have a corresponding PlatformCommunity.
     # We would need to delete the SlackCommunity as well, which we should show a warning for!
-    if community.platform == "slack":
-        return redirect("/main/settings?error=not_permitted")
+    if name == "slack":
+        return redirect("/main/settings?error=cant_delete_slack")
 
     logger.debug(f"Deleting plugin {name} {id}")
     MetagovAPI.delete_plugin(name=name, id=id)

--- a/policykit/policykit/urls.py
+++ b/policykit/policykit/urls.py
@@ -43,6 +43,7 @@ urlpatterns = [
     path('reddit/', include('integrations.reddit.urls')),
     path('discord/', include('integrations.discord.urls')),
     path('discourse/', include('integrations.discourse.urls')),
+    path('github/', include('integrations.github.urls')),
     url(r'^$', policyviews.homepage),
     url('^activity/', include('actstream.urls')),
     # path("schema/", Schema.as_view()),


### PR DESCRIPTION
Enable GitHub integration through Metagov. The installation view is entirely copied from the Slack installer view. Look into consolidating this logic into a "core" PolicyKit view.

I tested in a policy like this:
```
response = metagov.perform_action("github.method", {"method": "GET","route":"/repos/{owner}/{repo}/issues", "repo":"myrepo"})
debug(str(response))
```

In order to change the repos you have access to, you currently need to delete and re-enable the integration in PolicyKit, which is not ideal.