### PR TITLE
Minor fixes to starterkit initialization for secondary platforms

### DIFF
--- a/policykit/integrations/discord/views.py
+++ b/policykit/integrations/discord/views.py
@@ -438,7 +438,7 @@ def oauth(request):
         context = {
             "server_url": SERVER_URL,
             "starterkits": get_starterkits_info(),
-            "community_name": community.community_name,
+            "community_id": community.pk,
             "platform": "discord"
         }
         return render(request, "policyadmin/init_starterkit.html", context)

--- a/policykit/integrations/discourse/views.py
+++ b/policykit/integrations/discourse/views.py
@@ -132,7 +132,7 @@ def auth(request):
             context = {
                 "server_url": SERVER_URL,
                 "starterkits": get_starterkits_info(),
-                "community_name": community.community_name,
+                "community_id": community.pk,
                 "platform": "discourse"
             }
             return render(request, "policyadmin/init_starterkit.html", context)

--- a/policykit/integrations/reddit/views.py
+++ b/policykit/integrations/reddit/views.py
@@ -123,7 +123,7 @@ def init_community_reddit(request):
     context = {
         "server_url": SERVER_URL,
         "starterkits": get_starterkits_info(),
-        "community_name": community.community_name,
+        "community_id": community.pk,
         "creator_token": access_token,
         "platform": "reddit"
     }

--- a/policykit/integrations/slack/views.py
+++ b/policykit/integrations/slack/views.py
@@ -115,11 +115,11 @@ def slack_install(request):
         context = {
             "server_url": settings.SERVER_URL,
             "starterkits": get_starterkits_info(),
-            "community_name": slack_community.community_name,
+            "community_id": slack_community.pk,
             "creator_token": user_token,
             "platform": "slack",
             # redirect to settings page or login page depending on whether it's a new community
-            "redirect": redirect_route
+            "redirect": redirect_route,
         }
         return render(request, "policyadmin/init_starterkit.html", context)
 

--- a/policykit/policyengine/views.py
+++ b/policykit/policyengine/views.py
@@ -482,23 +482,19 @@ def initialize_starterkit(request):
     from policyengine.models import CommunityPlatform
 
     post_data = json.loads(request.body)
+    starterkit = post_data["starterkit"]
+    community = CommunityPlatform.objects.get(pk=post_data["community_id"])
 
-    logger.debug(f'Initializing with starter kit: {post_data["starterkit"]}')
+    logger.debug(f'Initializing community {community} with starter kit {starterkit}...')
     cur_path = os.path.abspath(os.path.dirname(__file__))
-    starter_kit_path = os.path.join(cur_path, f'../starterkits/{post_data["starterkit"]}.txt')
+    starter_kit_path = os.path.join(cur_path, f'../starterkits/{starterkit}.txt')
     f = open(starter_kit_path)
     kit_data = json.loads(f.read())
     f.close()
 
-    # TODO: Community name is not necessarily unique! Should use pk instead.
-    community = CommunityPlatform.objects.get(community_name=post_data["community_name"])
-
     initialize_starterkit_inner(community, kit_data, creator_token=post_data.get("creator_token"))
 
-    redirect_route = request.GET.get("redirect")
-    if redirect_route:
-        return JsonResponse({'redirect': f"{redirect_route}?success=true"})
-    return JsonResponse({'redirect': '/login?success=true'})
+    return JsonResponse({"ok": True})
 
 @csrf_exempt
 def error_check(request):

--- a/policykit/templates/policyadmin/init_starterkit.html
+++ b/policykit/templates/policyadmin/init_starterkit.html
@@ -101,13 +101,21 @@
         body: JSON.stringify({
           'starterkit': kit,
           'platform': decodeHtml(`{{platform}}`),
-          'community_name': decodeHtml(`{{community_name}}`),
+          'community_id': decodeHtml(`{{community_id}}`),
           'creator_token': decodeHtml(`{{creator_token}}`)
         })
       })
-      .then(response => response.json())
-      .then(data => {
-        window.location.href = `${data.redirect}?success=true`
+      .then(response => {
+        if (!response.ok) {
+          response.text().then(text => {
+            console.error("Error initializing starterkit:");
+            console.error(text);
+          })
+        } else {
+          const redirect = decodeHtml(`{{redirect}}`) || "/login"
+          console.log(`done, redirecting to ${redirect}`)
+          window.location.href = `${redirect}?success=true`
+        }
       });
     }
   </script>


### PR DESCRIPTION
A few fixes needed after https://github.com/amyxzhang/policykit/pull/435 to make starterkit installation work correctly when enabling "secondary" platform communities (e.g. I have PolicyKit in discord and I'm adding Slack too). Also includes a change  to use unique primary key to identify community during starterkit installation, instead of community_name which is not unique.