### PR TITLE
Execute community-originated governable actions in engine, and add more tests

### DIFF
--- a/policykit/integrations/discord/models.py
+++ b/policykit/integrations/discord/models.py
@@ -62,7 +62,7 @@ class DiscordPostMessage(GovernableAction):
         )
 
     def revert(self):
-        super().revert({}, f"channels/{self.channel_id}/messages/{self.message_id}", method='DELETE')
+        super().revert(call=f"channels/{self.channel_id}/messages/{self.message_id}", method='DELETE')
 
     def execute(self):
         # Execute action if it didn't originate in the community OR it was previously reverted
@@ -85,7 +85,7 @@ class DiscordDeleteMessage(GovernableAction):
         )
 
     def revert(self):
-        super().revert({'content': self.text}, f"channels/{self.channel_id}/messages")
+        super().revert(values={'content': self.text}, call=f"channels/{self.channel_id}/messages")
 
     def execute(self):
         # Execute action if it didn't originate in the community OR it was previously reverted
@@ -111,7 +111,7 @@ class DiscordRenameChannel(GovernableAction):
         )
 
     def revert(self):
-        super().revert({'name': self.name_old}, f"channels/{self.channel_id}", method='PATCH')
+        super().revert(values={'name': self.name_old}, call=f"channels/{self.channel_id}", method='PATCH')
 
         # Update DiscordChannel object
         c = DiscordChannel.objects.filter(channel_id=self.channel_id)
@@ -145,7 +145,7 @@ class DiscordCreateChannel(GovernableAction):
         )
 
     def revert(self):
-        super().revert({}, f"channels/{self.channel_id}", method='DELETE')
+        super().revert(call=f"channels/{self.channel_id}", method='DELETE')
 
     def execute(self):
         # Execute action if it didn't originate in the community OR it was previously reverted

--- a/policykit/integrations/discourse/models.py
+++ b/policykit/integrations/discourse/models.py
@@ -120,7 +120,7 @@ class DiscourseCreateTopic(GovernableAction):
     def revert(self):
         values = {}
         call = f"/t/{self.topic_id}.json"
-        super().revert(values, call, method='DELETE')
+        super().revert(values=values, call=call, method='DELETE')
 
     def execute(self):
         # Execute action if it didnt originate in the community
@@ -153,7 +153,7 @@ class DiscourseCreatePost(GovernableAction):
     def revert(self):
         values = {}
         call = f"/posts/{self.post_id}.json"
-        super().revert(values, call, method='DELETE')
+        super().revert(value=values, call=call, method='DELETE')
 
     def execute(self):
         # only execute the action if it didnt originate in the community, OR if it was previously reverted

--- a/policykit/integrations/reddit/models.py
+++ b/policykit/integrations/reddit/models.py
@@ -190,7 +190,7 @@ class RedditMakePost(GovernableAction):
 
     def revert(self):
         values = {'id': self.name}
-        super().revert(values, 'api/remove')
+        super().revert(values=values, call='api/remove')
 
     def execute(self):
         if not self.community_revert:

--- a/policykit/integrations/slack/models.py
+++ b/policykit/integrations/slack/models.py
@@ -273,7 +273,7 @@ class SlackPostMessage(GovernableAction):
             "ts": self.timestamp,
             "channel": self.channel,
         }
-        super().revert(values, SLACK_METHOD_ACTION)
+        super().revert(values=values, call=SLACK_METHOD_ACTION)
 
 
 class SlackRenameConversation(GovernableAction):
@@ -297,7 +297,7 @@ class SlackRenameConversation(GovernableAction):
             # Use the initiators access token if we have it (since they already successfully renamed)
             "token": self.initiator.access_token or self.community.__get_admin_user_token(),
         }
-        super().revert(values, SLACK_METHOD_ACTION)
+        super().revert(values=values, call=SLACK_METHOD_ACTION)
 
 
 class SlackJoinConversation(GovernableAction):
@@ -314,14 +314,14 @@ class SlackJoinConversation(GovernableAction):
     def revert(self):
         values = {"method_name": "conversations.kick", "user": self.users, "channel": self.channel}
         try:
-            super().revert(values, SLACK_METHOD_ACTION)
+            super().revert(values=values, call=SLACK_METHOD_ACTION)
         except Exception:
             # Whether or not bot can kick is based on workspace settings
             logger.error(f"kick with bot token failed, attempting with admin token")
             values["token"] = self.community.__get_admin_user_token()
             # This will fail with `cant_kick_self` if a user is trying to kick itself.
             # TODO: handle that by using a different token or `conversations.leave` if we have the user's token
-            super().revert(values, SLACK_METHOD_ACTION)
+            super().revert(values=values, call=SLACK_METHOD_ACTION)
 
 
 class SlackPinMessage(GovernableAction):
@@ -336,7 +336,7 @@ class SlackPinMessage(GovernableAction):
 
     def revert(self):
         values = {"method_name": "pins.remove", "channel": self.channel, "timestamp": self.timestamp}
-        super().revert(values, SLACK_METHOD_ACTION)
+        super().revert(values=values, call=SLACK_METHOD_ACTION)
 
 
 class SlackScheduleMessage(GovernableAction):

--- a/policykit/integrations/slack/models.py
+++ b/policykit/integrations/slack/models.py
@@ -70,7 +70,7 @@ class SlackCommunity(CommunityPlatform):
             return response.json()
         return None
 
-    def execute_platform_action(self, action, delete_policykit_post=True):
+    def execute_platform_action(self, action, delete_policykit_post=False):
         obj = action
 
         if not obj.community_origin or (obj.community_origin and obj.community_revert):

--- a/policykit/policyengine/engine.py
+++ b/policykit/policyengine/engine.py
@@ -262,10 +262,13 @@ def evaluate_proposal_inner(context: EvaluationContext, is_first_evaluation: boo
         assert proposal.status == Proposal.PASSED
 
         # EXECUTE the action if....
-        # it is a GovernableAction that was proposed in the PolicyKit UI
+        # It is a GovernableAction that was proposed in the PolicyKit UI
         if action.kind == PolicyActionKind.PLATFORM and not action.community_origin:
             action.execute()
-        # it is a constitution action
+        # It is a GovernableAction that originated on the platform and was previously reverted
+        elif action.kind == PolicyActionKind.PLATFORM and action.community_origin and action.community_revert:
+            action.execute()
+        # It is a constitution action
         elif action.kind == PolicyActionKind.CONSTITUTION:
             action.execute()
 

--- a/policykit/policyengine/engine.py
+++ b/policykit/policyengine/engine.py
@@ -261,15 +261,7 @@ def evaluate_proposal_inner(context: EvaluationContext, is_first_evaluation: boo
         proposal.pass_evaluation()
         assert proposal.status == Proposal.PASSED
 
-        # EXECUTE the action if....
-        # It is a GovernableAction that was proposed in the PolicyKit UI
-        if action.kind == PolicyActionKind.PLATFORM and not action.community_origin:
-            action.execute()
-        # It is a GovernableAction that originated on the platform and was previously reverted
-        elif action.kind == PolicyActionKind.PLATFORM and action.community_origin and action.community_revert:
-            action.execute()
-        # It is a constitution action
-        elif action.kind == PolicyActionKind.CONSTITUTION:
+        if action.is_executable:
             action.execute()
 
         if settings.METAGOV_ENABLED:
@@ -291,8 +283,7 @@ def evaluate_proposal_inner(context: EvaluationContext, is_first_evaluation: boo
     should_revert = (
         is_first_evaluation
         and check_result in [Proposal.PROPOSED, Proposal.FAILED]
-        and action.kind == PolicyActionKind.PLATFORM
-        and action.community_origin
+        and action.is_reversible
     )
 
     if should_revert:

--- a/policykit/policyengine/models.py
+++ b/policykit/policyengine/models.py
@@ -531,6 +531,32 @@ class BaseAction(PolymorphicModel):
         """The type of action (such as 'slackpostmessage' or 'policykitaddcommunitydoc')."""
         return self._meta.model_name
 
+    @property
+    def is_reversible(self):
+        if self.kind in [PolicyActionKind.TRIGGER, PolicyActionKind.CONSTITUTION]:
+            return False
+        return self.kind == PolicyActionKind.PLATFORM and self.community_origin
+
+    @property
+    def is_executable(self):
+        if self.kind == PolicyActionKind.TRIGGER:
+            # Trigger actions can never be executed
+            return False
+
+        if self.kind == PolicyActionKind.CONSTITUTION:
+            # Constitution actions can always be executed
+            return True
+
+        if self.kind == PolicyActionKind.PLATFORM and not self.community_origin:
+            # Governable platform actions proposed in the PolicyKit UI can be executed.
+            return True
+
+        if self.kind == PolicyActionKind.PLATFORM and self.community_origin and self.community_revert:
+            # Governable platform actions that originated on the platform and have previously reverted, can be executed.
+            return True
+
+        return False
+
 
 class TriggerAction(BaseAction, PolymorphicModel):
     """Trigger Action"""
@@ -573,21 +599,23 @@ class GovernableAction(BaseAction, PolymorphicModel):
             # Runs if initiator has propose permission, OR if there is no initiator.
             can_propose_perm = f"{self._meta.app_label}.add_{self.action_type}"
             if self.initiator and not self.initiator.has_perm(can_propose_perm):
-                logger.debug(f"Reverting proposed action because initiator does not have permission '{can_propose_perm}'")
-                super(GovernableAction, self).save(*args, **kwargs)
-                self.revert()
-                actstream_action.send(self, verb='was reverted due to lack of permissions', community_id=self.community.id, action_codename=self.action_type)
+                if self.is_reversible:
+                    logger.debug(f"Reverting proposed action because initiator does not have permission '{can_propose_perm}'")
+                    super(GovernableAction, self).save(*args, **kwargs)
+                    self.revert()
+                    actstream_action.send(self, verb='was reverted due to lack of permissions', community_id=self.community.id, action_codename=self.action_type)
             else:
                 super(GovernableAction, self).save(*args, **kwargs)
                 engine.evaluate_action(self)
 
         super(GovernableAction, self).save(*args, **kwargs)
 
-    def revert(self, values, call, method=None):
+    def revert(self, values=None, call=None, method=None):
         """
         Reverts the action.
         """
-        _ = LogAPICall.make_api_call(self.community, values, call, method=method)
+        if call:
+            LogAPICall.make_api_call(self.community, values or {}, call, method=method)
         self.community_revert = True
         self.save()
 

--- a/policykit/templates/policyadmin/dashboard/editor.html
+++ b/policykit/templates/policyadmin/dashboard/editor.html
@@ -331,7 +331,7 @@
     "initialize": "pass\n\n",
     "check": "return PASSED\n\n",
     "notify": "pass\n\n",
-    "pass": "action.execute()\n\n",
+    "pass": "pass\n\n",
     "fail": "pass\n\n"
   };
 

--- a/policykit/tests/test_evaluation.py
+++ b/policykit/tests/test_evaluation.py
@@ -172,7 +172,7 @@ class EvaluationTests(TestCase):
         user = SlackUser.objects.create(username="test-user", community=self.slack_community)
         self.assertEqual(user.has_perm(f"constitution.{PROPOSE_COMMUNITY_DOC_PERM}"), False)
         action = self.new_policykitaddcommunitydoc(initiator=user)
-        self.evaluate_action_helper(action, expected_did_execute=False, expected_did_revert=True)
+        self.evaluate_action_helper(action, expected_did_execute=False)
 
         # action initiated by user with "can_add" should pass
         user = SlackUser.objects.create(username="second-user", community=self.slack_community)

--- a/policykit/tests/test_evaluation.py
+++ b/policykit/tests/test_evaluation.py
@@ -168,11 +168,11 @@ class EvaluationTests(TestCase):
         base_role.permissions.remove(can_add)
         base_role.save()
 
-        # action initiated by user without "can_add" should fail
+        # action initiated by user without "can_add" should be reverted
         user = SlackUser.objects.create(username="test-user", community=self.slack_community)
         self.assertEqual(user.has_perm(f"constitution.{PROPOSE_COMMUNITY_DOC_PERM}"), False)
         action = self.new_policykitaddcommunitydoc(initiator=user)
-        self.evaluate_action_helper(action, expected_did_execute=False)
+        self.evaluate_action_helper(action, expected_did_execute=False, expected_did_revert=True)
 
         # action initiated by user with "can_add" should pass
         user = SlackUser.objects.create(username="second-user", community=self.slack_community)


### PR DESCRIPTION
### Changes
* Community-originated governable actions that are proposed by a user who lacks `can_add_` perm get reverted. (No policy is evaluated, though, so no Proposal is created).
* Community-originated governable actions that have been previously reverted are automatically executed when moved from PROPOSED=>PASSED state. 


### New unit tests
* test that constitution actions are executed at the correct time for sync and async governing policies
* test that platform actions that occurred on platform (`community_origin=True`) are reverted and executed at the correct time for sync and async governing policies
* test that platform actions that were proposed in the PK UI are executed at the correct time for sync and async governing policies