### PR TITLE
Fix bug where users could edit policies and roles of other communities

### DIFF
--- a/policykit/policyengine/views.py
+++ b/policykit/policyengine/views.py
@@ -299,7 +299,10 @@ def roleeditor(request):
     }
 
     if role_pk:
-        role = CommunityRole.objects.get(pk=role_pk, community=user.community.community)
+        try:
+            role = CommunityRole.objects.get(pk=role_pk, community=user.community.community)
+        except CommunityRole.DoesNotExist:
+            return HttpResponseNotFound()
         data['role_name'] = role.role_name
         data['name'] = role.name
         data['description'] = role.description
@@ -676,7 +679,10 @@ def role_action_remove(request):
     action = PolicykitDeleteRole()
     action.community = user.constitution_community
     action.initiator = user
-    action.role = CommunityRole.objects.get(pk=data['role'], community=user.community.community)
+    try:
+        action.role = CommunityRole.objects.get(pk=data['role'], community=user.community.community)
+    except CommunityRole.DoesNotExist:
+        return HttpResponseNotFound()
     action.save()
 
     return HttpResponse()
@@ -694,7 +700,10 @@ def document_action_save(request):
         action = PolicykitAddCommunityDoc()
     elif data['operation'] == 'Change':
         action = PolicykitChangeCommunityDoc()
-        action.doc = CommunityDoc.objects.filter(id=data['doc'])[0]
+        try:
+            action.doc = CommunityDoc.objects.get(id=data['doc'], community=user.community.community)
+        except CommunityDoc.DoesNotExist:
+            return HttpResponseNotFound()
     else:
         return HttpResponseBadRequest()
 
@@ -717,7 +726,10 @@ def document_action_remove(request):
     action = PolicykitDeleteCommunityDoc()
     action.community = user.constitution_community
     action.initiator = user
-    action.doc = CommunityDoc.objects.get(id=data['doc'], community=user.community.community)
+    try:
+        action.doc = CommunityDoc.objects.get(id=data['doc'], community=user.community.community)
+    except CommunityDoc.DoesNotExist:
+        return HttpResponseNotFound()
     action.save()
 
     return HttpResponse()
@@ -733,7 +745,10 @@ def document_action_recover(request):
     action = PolicykitRecoverCommunityDoc()
     action.community = user.constitution_community
     action.initiator = user
-    action.doc = CommunityDoc.objects.get(id=data['doc'], community=user.community.community)
+    try:
+        action.doc = CommunityDoc.objects.get(id=data['doc'], community=user.community.community)
+    except CommunityDoc.DoesNotExist:
+        return HttpResponseNotFound()
     action.save()
 
     return HttpResponse()

--- a/policykit/policyengine/views.py
+++ b/policykit/policyengine/views.py
@@ -189,6 +189,7 @@ def disable_integration(request):
     MetagovAPI.delete_plugin(name=name, id=id)
     return redirect("/main/settings")
 
+
 @login_required(login_url='/login')
 def editor(request):
     kind = request.GET.get('type', "platform").lower()
@@ -219,7 +220,9 @@ def editor(request):
         try:
             policy = Policy.objects.get(id=policy_id)
         except Policy.DoesNotExist:
-            return HttpResponseBadRequest()
+            return HttpResponseNotFound()
+        if policy.community != user.community.community:
+            return HttpResponseNotFound()
 
         data['policy'] = policy_id
         data['name'] = policy.name
@@ -499,6 +502,8 @@ def policy_action_save(request):
             action.policy = Policy.objects.get(pk=data['policy'])
         except Policy.DoesNotExist:
             return HttpResponseNotFound()
+        if action.policy.community != user.community.community:
+            return HttpResponseNotFound()
 
     else:
         return HttpResponseNotFound()
@@ -552,6 +557,9 @@ def policy_action_remove(request):
         policy = Policy.objects.get(pk=data['policy'])
     except Policy.DoesNotExist:
         return HttpResponseNotFound()
+    if policy.community != user.community.community:
+        return HttpResponseNotFound()
+
     if policy.kind == Policy.CONSTITUTION:
         action = PolicykitRemoveConstitutionPolicy()
         action.policy = policy
@@ -580,6 +588,9 @@ def policy_action_recover(request):
         policy = Policy.objects.get(pk=data['policy'])
     except Policy.DoesNotExist:
         return HttpResponseNotFound()
+    if policy.community != user.community.community:
+        return HttpResponseNotFound()
+
     if policy.kind == Policy.CONSTITUTION:
         action = PolicykitRecoverConstitutionPolicy()
         action.policy = policy


### PR DESCRIPTION
Fix a bug where users could manipulate IDs in the query string (like `https://policykit.org/main/editor/?type=Platform&operation=Change&policy=3`) to view and edit policies from other communities. This updates all views to check that the document being requested belongs to the community that the user is logged in to.