### PR TITLE
Add `find_linked_username` to CommunityUser for identity resolution

### DIFF
--- a/policykit/integrations/metagov/api.py
+++ b/policykit/integrations/metagov/api.py
@@ -62,7 +62,7 @@ def find_metagov_id(platform_type, community_platform_id, platform_identifier):
     if not users:
         return None
     if len(users) > 1:
-        raise Exception
+        raise Exception("More than 1 matching user found")
     return users[0]["source_ID"]
 
 

--- a/policykit/integrations/metagov/api.py
+++ b/policykit/integrations/metagov/api.py
@@ -45,11 +45,12 @@ def get_metagov_community(slug):
 #### IDENTITY MANAGEMENT ####
 
 
-def find_metagov_id(platform_type, community_platform_id, platform_identifier):
+def find_metagov_id(community, platform_type, community_platform_id, platform_identifier):
     logger.debug(f">> user lookup for {platform_identifier} on {platform_type}:{community_platform_id}")
     response = requests.get(
-        f"{settings.METAGOV_URL}/api/internal/users",
+        f"{settings.METAGOV_URL}/api/internal/identity/get_users",
         params={
+            "community": community,
             "platform_type": platform_type,
             "community_platform_id": community_platform_id,
             "platform_identifier": platform_identifier,

--- a/policykit/integrations/metagov/api.py
+++ b/policykit/integrations/metagov/api.py
@@ -24,7 +24,6 @@ def create_empty_metagov_community(readable_name=""):
     return response.json()
 
 
-
 def update_metagov_community(community, plugins=[]):
     if not community.metagov_slug:
         raise Exception(f"no metagov slug for {community}")
@@ -42,8 +41,34 @@ def get_metagov_community(slug):
         raise Exception(response.text or "Unknown error")
     return response.json()
 
+
+#### IDENTITY MANAGEMENT ####
+
+
+def find_metagov_id(platform_type, community_platform_id, platform_identifier):
+    logger.debug(f">> user lookup for {platform_identifier} on {platform_type}:{community_platform_id}")
+    response = requests.get(
+        f"{settings.METAGOV_URL}/api/internal/users",
+        params={
+            "platform_type": platform_type,
+            "community_platform_id": community_platform_id,
+            "platform_identifier": platform_identifier,
+        },
+    )
+    if not response.ok:
+        raise Exception(response.text or "Unknown error")
+    users = response.json()
+    logger.debug(f">> Metagov user request returned {users}")
+    if not users:
+        return None
+    if len(users) > 1:
+        raise Exception
+    return users[0]["source_ID"]
+
+
 #### PLUGIN MANAGEMENT ####
 plugin_base = f"{settings.METAGOV_URL}/api/internal/plugin"
+
 
 def enable_plugin(community_slug, name, config):
     headers = {"X-Metagov-Community": community_slug}
@@ -52,12 +77,15 @@ def enable_plugin(community_slug, name, config):
         raise Exception(response.text or "Unknown error")
     return response.json()
 
+
 def delete_plugin(name: str, id):
     response = requests.delete(f"{plugin_base}/{name}/{id}")
     if not response.ok and response.status_code != 404:
         raise Exception(response.text or "Unknown error")
 
+
 #### SCHEMAS ####
+
 
 def get_plugin_config_schemas():
     url = f"{settings.METAGOV_URL}/api/internal/plugin-schemas"
@@ -65,6 +93,7 @@ def get_plugin_config_schemas():
     if not response.ok:
         raise Exception(response.text or "Unknown error")
     return response.json()
+
 
 def get_plugin_metadata(plugin):
     url = f"{settings.METAGOV_URL}/api/internal/plugin/{plugin}/metadata"

--- a/policykit/integrations/metagov/api.py
+++ b/policykit/integrations/metagov/api.py
@@ -45,8 +45,7 @@ def get_metagov_community(slug):
 #### IDENTITY MANAGEMENT ####
 
 
-def get_metagov_users(community, platform_type, community_platform_id, platform_identifier):
-    logger.debug(f">> user lookup for {platform_identifier} on {platform_type}:{community_platform_id}")
+def get_metagov_user(community, platform_type, community_platform_id, platform_identifier):
     response = requests.get(
         f"{settings.METAGOV_URL}/api/internal/identity/get_users",
         params={
@@ -59,7 +58,6 @@ def get_metagov_users(community, platform_type, community_platform_id, platform_
     if not response.ok:
         raise Exception(response.text or "Unknown error")
     users = response.json()
-    logger.debug(f">> Metagov user request returned {users}")
     if len(users) > 1:
         raise Exception("More than 1 matching user found")
     return None if not users else users[0]

--- a/policykit/integrations/metagov/api.py
+++ b/policykit/integrations/metagov/api.py
@@ -45,7 +45,7 @@ def get_metagov_community(slug):
 #### IDENTITY MANAGEMENT ####
 
 
-def find_metagov_id(community, platform_type, community_platform_id, platform_identifier):
+def get_metagov_users(community, platform_type, community_platform_id, platform_identifier):
     logger.debug(f">> user lookup for {platform_identifier} on {platform_type}:{community_platform_id}")
     response = requests.get(
         f"{settings.METAGOV_URL}/api/internal/identity/get_users",
@@ -60,12 +60,9 @@ def find_metagov_id(community, platform_type, community_platform_id, platform_id
         raise Exception(response.text or "Unknown error")
     users = response.json()
     logger.debug(f">> Metagov user request returned {users}")
-    if not users:
-        return None
     if len(users) > 1:
         raise Exception("More than 1 matching user found")
-    return users[0]["source_ID"]
-
+    return None if not users else users[0]
 
 #### PLUGIN MANAGEMENT ####
 plugin_base = f"{settings.METAGOV_URL}/api/internal/plugin"

--- a/policykit/integrations/metagov/models.py
+++ b/policykit/integrations/metagov/models.py
@@ -24,14 +24,6 @@ class MetagovUser(CommunityUser):
             return self.username[len(prefix) :]
         return self.username
 
-    # def get_metagov_id(self):
-    #     return MetagovAPI.find_metagov_id(
-    #         community=self.community.community.metagov_slug,
-    #         platform_type=self.provider,
-    #         #community_platform_id=self.community.team_id,
-    #         platform_identifier=self.external_username  
-    #     )
-
 class MetagovConfig(models.Model):
     """
     Dummy model for permissions to edit Metagov Config.

--- a/policykit/integrations/metagov/models.py
+++ b/policykit/integrations/metagov/models.py
@@ -3,7 +3,6 @@ import logging
 
 from django.db import models
 from policyengine.models import CommunityUser, TriggerAction
-import integrations.metagov.api as MetagovAPI
 
 logger = logging.getLogger(__name__)
 

--- a/policykit/integrations/metagov/models.py
+++ b/policykit/integrations/metagov/models.py
@@ -3,6 +3,7 @@ import logging
 
 from django.db import models
 from policyengine.models import CommunityUser, TriggerAction
+import integrations.metagov.api as MetagovAPI
 
 logger = logging.getLogger(__name__)
 
@@ -23,6 +24,13 @@ class MetagovUser(CommunityUser):
             return self.username[len(prefix) :]
         return self.username
 
+    # def get_metagov_id(self):
+    #     return MetagovAPI.find_metagov_id(
+    #         community=self.community.community.metagov_slug,
+    #         platform_type=self.provider,
+    #         #community_platform_id=self.community.team_id,
+    #         platform_identifier=self.external_username  
+    #     )
 
 class MetagovConfig(models.Model):
     """

--- a/policykit/integrations/metagov/views.py
+++ b/policykit/integrations/metagov/views.py
@@ -82,13 +82,13 @@ def internal_receive_action(request):
             cp.handle_metagov_event(body)
             return HttpResponse()
 
-    # if body.get("source") == "github":
-    #     # Route Slack event to the correct SlackCommunity handler
-    #     cp = GithubCommunity.objects.filter(community=community).first()
-    #     if cp:
-    #         new_action = cp.handle_metagov_event(body)
-    #         if new_action:
-    #             return HttpResponse()
+    if body.get("source") == "github":
+        # Route Slack event to the correct SlackCommunity handler
+        cp = GithubCommunity.objects.filter(community=community).first()
+        if cp:
+            new_action = cp.handle_metagov_event(body)
+            if new_action:
+                return HttpResponse()
 
     # Create generic MetagovTriggers.
     cp = community.get_platform_communities().first()

--- a/policykit/integrations/metagov/views.py
+++ b/policykit/integrations/metagov/views.py
@@ -82,13 +82,13 @@ def internal_receive_action(request):
             cp.handle_metagov_event(body)
             return HttpResponse()
 
-    if body.get("source") == "github":
-        # Route Slack event to the correct SlackCommunity handler
-        cp = GithubCommunity.objects.filter(community=community).first()
-        if cp:
-            new_action = cp.handle_metagov_event(body)
-            if new_action:
-                return HttpResponse()
+    # if body.get("source") == "github":
+    #     # Route Slack event to the correct SlackCommunity handler
+    #     cp = GithubCommunity.objects.filter(community=community).first()
+    #     if cp:
+    #         new_action = cp.handle_metagov_event(body)
+    #         if new_action:
+    #             return HttpResponse()
 
     # Create generic MetagovTriggers.
     cp = community.get_platform_communities().first()

--- a/policykit/policyengine/models.py
+++ b/policykit/policyengine/models.py
@@ -244,17 +244,16 @@ class CommunityUser(User, PolymorphicModel):
         return self.readable_name if self.readable_name else self.username
 
     def find_linked_username(self, platform):
-        user = MetagovAPI.get_metagov_users(
+        user = MetagovAPI.get_metagov_user(
             community=self.community.community.metagov_slug,
             platform_type=self.community.platform,
             community_platform_id=self.community.team_id,
             platform_identifier=self.username
         )
-        if not user:
-            return None
-        for account in user["linked_accounts"]:
-            if account["platform_type"] == platform:
-                return account["platform_identifier"]
+        if user:
+            for account in user["linked_accounts"]:
+                if account["platform_type"] == platform:
+                    return account["platform_identifier"]
         return None
 
     def get_metagov_id(self):

--- a/policykit/policyengine/models.py
+++ b/policykit/policyengine/models.py
@@ -245,6 +245,7 @@ class CommunityUser(User, PolymorphicModel):
 
     def get_metagov_id(self):
         return MetagovAPI.find_metagov_id(
+            community=self.community.community.metagov_slug,
             platform_type=self.community.platform,
             community_platform_id=self.community.team_id,
             platform_identifier=self.username

--- a/policykit/policyengine/models.py
+++ b/policykit/policyengine/models.py
@@ -256,15 +256,6 @@ class CommunityUser(User, PolymorphicModel):
                     return account["platform_identifier"]
         return None
 
-    def get_metagov_id(self):
-        user = MetagovAPI.find_metagov_id(
-            community=self.community.community.metagov_slug,
-            platform_type=self.community.platform,
-            community_platform_id=self.community.team_id,
-            platform_identifier=self.username
-        )
-        return user["source_ID"] if user else None
-
     def get_roles(self):
         """
         Returns a list of CommunityRoles containing all of the user's roles.

--- a/policykit/policyengine/models.py
+++ b/policykit/policyengine/models.py
@@ -243,13 +243,28 @@ class CommunityUser(User, PolymorphicModel):
     def __str__(self):
         return self.readable_name if self.readable_name else self.username
 
-    def get_metagov_id(self):
-        return MetagovAPI.find_metagov_id(
+    def find_linked_username(self, platform):
+        user = MetagovAPI.get_metagov_users(
             community=self.community.community.metagov_slug,
             platform_type=self.community.platform,
             community_platform_id=self.community.team_id,
             platform_identifier=self.username
         )
+        if not user:
+            return None
+        for account in user["linked_accounts"]:
+            if account["platform_type"] == platform:
+                return account["platform_identifier"]
+        return None
+
+    def get_metagov_id(self):
+        user = MetagovAPI.find_metagov_id(
+            community=self.community.community.metagov_slug,
+            platform_type=self.community.platform,
+            community_platform_id=self.community.team_id,
+            platform_identifier=self.username
+        )
+        return user["source_ID"] if user else None
 
     def get_roles(self):
         """

--- a/policykit/policyengine/models.py
+++ b/policykit/policyengine/models.py
@@ -243,6 +243,13 @@ class CommunityUser(User, PolymorphicModel):
     def __str__(self):
         return self.readable_name if self.readable_name else self.username
 
+    def get_metagov_id(self):
+        return MetagovAPI.find_metagov_id(
+            platform_type=self.community.platform,
+            community_platform_id=self.community.team_id,
+            platform_identifier=self.username
+        )
+
     def get_roles(self):
         """
         Returns a list of CommunityRoles containing all of the user's roles.


### PR DESCRIPTION
Tested on a Policy that finds a linked GitHub account from a SlackUser:
```
# action is a SlackPostMessage, and my Slack and Github accounts had been previously linked through Metagov
username = action.initiator.find_linked_username(platform="github")
logger.debug(f"github username: {username}")
# elided: post on github and tag the initiating slack user's github account
```
https://github.com/mashton/metagov-test-repo/issues/12