### PR TITLE
Remove unnecessary logging, retain database logs

### DIFF
--- a/policykit/integrations/metagov/library.py
+++ b/policykit/integrations/metagov/library.py
@@ -46,7 +46,6 @@ class Metagov:
         response = requests.get(self.proposal.governance_process_url)
         if not response.ok:
             raise Exception(f"Error getting process: {response.status_code} {response.reason} {response.text}")
-        logger.debug(response.text)
 
         # store the outcome data on the proposal
         self.proposal.governance_process_json = response.text

--- a/policykit/integrations/metagov/views.py
+++ b/policykit/integrations/metagov/views.py
@@ -72,7 +72,6 @@ def internal_receive_action(request):
         body = json.loads(request.body)
     except ValueError:
         return HttpResponseBadRequest("unable to decode body")
-    logger.info(f"Received metagov action: {body}")
 
     metagov_community_slug = body.get("community")
 
@@ -84,6 +83,9 @@ def internal_receive_action(request):
 
     # Special cases for receiving events from "governable platforms" that have fully featured integrations
     event_platform = body["source"]
+
+    logger.debug(f"Received metagov action: {event_platform} {body['event_type']} for {community}")
+
     if event_platform == "slack":
         cp = SlackCommunity.objects.filter(community=community).first()
         if cp:

--- a/policykit/integrations/slack/models.py
+++ b/policykit/integrations/slack/models.py
@@ -118,9 +118,9 @@ class SlackCommunity(CommunityPlatform):
         """
         Receive Slack Metagov Event for this community
         """
-        logger.debug(f"SlackCommunity recieved metagov event: {outer_event['event_type']}")
+        # logger.debug(f"SlackCommunity recieved metagov event: {outer_event['event_type']}")
         if outer_event["initiator"].get("is_metagov_bot") == True:
-            logger.debug("Ignoring bot event")
+            # logger.debug("Ignoring bot event")
             return
 
         new_api_action = SlackUtils.slack_event_to_platform_action(self, outer_event)

--- a/policykit/policyengine/engine.py
+++ b/policykit/policyengine/engine.py
@@ -273,7 +273,7 @@ def evaluate_proposal_inner(context: EvaluationContext, is_first_evaluation: boo
     # Run "check" block of policy
     check_result = exec_code_block(policy.check, context, Policy.CHECK)
     check_result = sanitize_check_result(check_result)
-    context.logger.debug(f"Check returned '{check_result}'")
+    # context.logger.debug(f"Check returned '{check_result}'")
 
     if check_result == Proposal.PASSED:
         # run "pass" block of policy

--- a/policykit/policyengine/tasks.py
+++ b/policykit/policyengine/tasks.py
@@ -30,14 +30,14 @@ def consider_proposed_actions():
             ExecutedActionTriggerAction.from_action(proposal.action).evaluate()
 
     clean_up_logs()
-    logger.debug("finished task")
+    # logger.debug("finished task")
 
 
 def clean_up_logs():
     from django_db_logger.models import EvaluationLog
-    from policykit.settings import DB_LOG_EXPIRATION_HOURS
+    from policykit.settings import DB_MAX_LOGS_TO_KEEP
 
-    hours_ago = timezone.now() - timezone.timedelta(hours=DB_LOG_EXPIRATION_HOURS)
-    count, _ = EvaluationLog.objects.filter(create_datetime__lt=hours_ago).delete()
-    if count:
-        logger.debug(f"Deleted {count} EvaluationLogs")
+    expired_logs = EvaluationLog.objects.all().order_by('-create_datetime')[DB_MAX_LOGS_TO_KEEP:]
+    if expired_logs.exists():
+        # logger.debug(f"Deleting {expired_logs.count()} EvaluationLogs")
+        expired_logs.delete()

--- a/policykit/policykit/settings.py
+++ b/policykit/policykit/settings.py
@@ -203,8 +203,8 @@ loggers[""] = {"handlers": ["console", "file"], "level": "WARN"}
 # Override for specific apps
 # loggers['integrations.reddit'] = {'handlers': ['console', 'file'], 'level': "DEBUG"}
 
-# Delete db log records from database after a certain number of hours:
-DB_LOG_EXPIRATION_HOURS = 1
+# Maximum number of log records to keep
+DB_MAX_LOGS_TO_KEEP = 300
 
 LOGGING = {
     'version': 1,


### PR DESCRIPTION
Instead of deleting old db logs based on time, keep a certain number of logs. The number can be adjusted via `DB_MAX_LOGS_TO_KEEP`. We have communities with relatively few logs total, but we want to watch them over many days/weeks because votes occur over longer time periods.