### PR TITLE
Fix bugs in safe restricted-python evaluation

### DIFF
--- a/policykit/policyengine/linter.py
+++ b/policykit/policyengine/linter.py
@@ -3,7 +3,7 @@ from pylint.reporters.text import TextReporter
 import tempfile
 import os
 import policyengine.utils as Utils
-from policyengine.safe_exec_code import BUILTINS, STATIC_GLOBAL_VARIABLES
+from policyengine.safe_exec_code import policykit_builtins, STATIC_GLOBAL_VARIABLES
 
 
 defined_variables = (
@@ -14,7 +14,7 @@ defined_variables = (
         "metagov",
         "logger",
     ]
-    + list(BUILTINS.keys())
+    + list(policykit_builtins.keys())
     + list(STATIC_GLOBAL_VARIABLES.keys())
     + Utils.get_platform_integrations() # not all of these are necessarily defined
 )

--- a/policykit/policyengine/safe_exec_code.py
+++ b/policykit/policyengine/safe_exec_code.py
@@ -1,6 +1,6 @@
 from RestrictedPython import safe_builtins, utility_builtins, compile_restricted
 from RestrictedPython import RestrictingNodeTransformer
-from RestrictedPython.Eval import default_guarded_getitem
+from RestrictedPython.Eval import default_guarded_getitem, default_guarded_getiter
 
 
 # permitted modules
@@ -63,6 +63,7 @@ def execute_user_code(user_code: str, user_func: str, *args, **kwargs):
         restricted_globals = {
             "__builtins__": BUILTINS,
             "_getitem_": default_guarded_getitem,
+            "_getiter_": default_guarded_getiter,
             "_getattr_": getattr,
             "_inplacevar_": lambda op, val, expr: val + expr,  # permit +=
             # to access args and kwargs

--- a/policykit/policykit/settings.py
+++ b/policykit/policykit/settings.py
@@ -99,6 +99,9 @@ METAGOV_SETTINGS = {
         "BOT_TOKEN": env("DISCORD_BOT_TOKEN", default=None),
         "PUBLIC_KEY": env("DISCORD_PUBLIC_KEY", default=None),
         "PERMISSIONS": env("DISCORD_PERMISSIONS", default=397821540358),
+    },
+    "OPENCOLLECTIVE": {
+        "USE_STAGING": env("OPENCOLLECTIVE_USE_STAGING", default=False)
     }
 }
 


### PR DESCRIPTION
* Use safe getattr method to restrict access to `_`-prefixed attributes
* Add guards for iterators to make lists and loops work
* https://github.com/amyxzhang/policykit/pull/533/commits/8516a3def1f94de7f4455347ccce2aa7edd7e097 Fix bug where `strftime` was raising an exception https://github.com/amyxzhang/policykit/issues/534
* https://github.com/amyxzhang/policykit/pull/533/commits/8516a3def1f94de7f4455347ccce2aa7edd7e097 Include line numbers for syntax errors in web log viewer:
    <img width="245" alt="Screen Shot 2021-12-27 at 22 29 55" src="https://user-images.githubusercontent.com/5333982/147525172-f18dfcda-c5f0-44bd-8ba3-337083f02f29.png">
    <img width="261" alt="Screen Shot 2021-12-27 at 22 29 22" src="https://user-images.githubusercontent.com/5333982/147525173-820613ee-3d46-4cc6-8a46-75efd73f9231.png">

