### PR TITLE
Increase number of EvaluationLogs kept at a time

### DIFF
--- a/policykit/policykit/settings.py
+++ b/policykit/policykit/settings.py
@@ -235,7 +235,7 @@ loggers[""] = {"handlers": ["console", "file"], "level": "WARN"}
 loggers['metagov'] = {'handlers': ['console', 'file'], 'level': "DEBUG", "propagate": False}
 
 # Maximum number of log records to keep
-DB_MAX_LOGS_TO_KEEP = 300
+DB_MAX_LOGS_TO_KEEP = 5000
 
 LOGGING = {
     'version': 1,


### PR DESCRIPTION
I keep losing log history when I pick up an issue after, say, a weekend away from it, so bumping this up in the hope that it will solve that problem. I don't think 5000 logs in the DB should cause any performance issues.