### PR TITLE
Save action before evaluating

### DIFF
--- a/policykit/policyengine/models.py
+++ b/policykit/policyengine/models.py
@@ -652,6 +652,7 @@ class GovernableAction(BaseAction, PolymorphicModel):
 
             if self.initiator and self.initiator.has_perm(can_execute_perm):
                 self.execute()  # No `Proposal` is created because we don't evaluate it
+                super(GovernableAction, self).save(*args, **kwargs)
                 ExecutedActionTriggerAction.from_action(self).evaluate()
 
             elif self.initiator and not self.initiator.has_perm(can_propose_perm):


### PR DESCRIPTION
I encountered a bug when testing a Trigger policy for a new Matrix integration I was writing: `ValueError: save() prohibited to prevent data loss due to unsaved related object 'action'.` This was happening because `ExecutedActionTriggerAction.from_action(self).evaluate()` creates a TriggerAction containing the unsaved GovernableAction, which later gets saved when `create_prefiltered_proposals` gets called on it. Adding this line resolves the error.