### PR TITLE
Fixed a bug in revising the code view of a custom procedure in the new interface. 

### DIFF
--- a/policykit/policyengine/engine.py
+++ b/policykit/policyengine/engine.py
@@ -89,6 +89,7 @@ class EvaluationContext:
         Initialize policy variables according to their default values or codes.
         """
         # Make policy variables available in the evaluation context
+        from policyengine.models import PolicyVariable
         setattr(self, "variables", AttrDict({}))
         logger.debug(f"Initialized variables codes: {initialize}")
         variables = exec_code_block(initialize, self, "initialize")
@@ -99,7 +100,7 @@ class EvaluationContext:
             # confused about what this code is for.
             if variable.entity and Utils.check_code_variables(variable.value):
                 # make sure variables value after the initialization is still valid
-                variables[variable.name] = variable.validate_value(variables[variable.name])
+                variables[variable.name] = PolicyVariable.validate_value(variable.to_json(), variables[variable.name])
                 # logger.debug(f"variable name: {variable.name}, value: {variables[variable.name]}")
 
 

--- a/policykit/policykit/settings.py
+++ b/policykit/policykit/settings.py
@@ -270,7 +270,7 @@ LOGGING = {
     'version': 1,
     'disable_existing_loggers': False,
     'formatters': {
-        "console": {"format": "%(name)-12s %(levelname)-8s %(message)s"},
+        "console": {"format": "%(name)-12s %(levelname)-8s %(filename)s:%(lineno)d %(message)s"},
         "json": {"()": "django_datadog_logger.formatters.datadog.DataDogJSONFormatter"},
     },
     'handlers': {

--- a/policykit/templates/no-code/main.html
+++ b/policykit/templates/no-code/main.html
@@ -1705,11 +1705,14 @@
         changeFocusSection();
         if(policytemplate.procedure.view === "codes"){
             let procedure = policytemplate.procedure;
+            // Set selected_procedure so collectProcedureData can retrieve the procedure value
+            selected_procedure = procedure;
             showCodeEditor("procedure", null, {
                 initialize: procedure.initialize,
                 check: procedure.check,
                 notify: procedure.notify
             });
+            editor_status["procedure"] = "changed";
         } else {
             showProcedureVariables(
                 policytemplate.procedure.value,


### PR DESCRIPTION
the bug was very specific. 
I first authored a policy and switched to the code vesion for the procedure component, then saved the policy. Then i revisited this policy at this page, and made some edits to the code of the procedure component. Then when i tried to save the changed policy, it will scroll the screen to focus on the procedure code component again, and somehow reminded me that i still needed to do something in order to save the policy, even though the desired behavior should be that i can save the policy directly. 